### PR TITLE
Feature/tao 9038/add platform options

### DIFF
--- a/config/default/DeliveryExecutionFinderService.conf.php
+++ b/config/default/DeliveryExecutionFinderService.conf.php
@@ -1,3 +1,6 @@
 <?php
 
-return new \oat\ltiTestReview\models\DeliveryExecutionFinderService();
+return new \oat\ltiTestReview\models\DeliveryExecutionFinderService([
+    'show_score' => false,
+    'show_correct' => false
+]);

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'Test Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.11.0',
+    'version' => '1.12.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -39,8 +39,10 @@ class DeliveryExecutionFinderService extends ConfigurableService
     public const SERVICE_ID = 'ltiTestReview/DeliveryExecutionFinderService';
 
     public const LTI_SOURCE_ID = 'lis_result_sourcedid';
-    public const OPTION_SHOW_SCORE = 'custom_show_score';
-    public const OPTION_SHOW_CORRECT = 'custom_show_correct';
+    public const OPTION_SHOW_SCORE = 'show_score';
+    public const OPTION_SHOW_CORRECT = 'show_correct';
+    public const LTI_SHOW_SCORE = 'custom_show_score';
+    public const LTI_SHOW_CORRECT = 'custom_show_correct';
 
     /**
      * @param LtiLaunchData $launchData
@@ -82,7 +84,7 @@ class DeliveryExecutionFinderService extends ConfigurableService
      */
     public function getShowScoreOption(LtiLaunchData $launchData): bool
     {
-        return $this->getBooleanOption($launchData, self::OPTION_SHOW_SCORE);
+        return $this->getBooleanOption($launchData, self::LTI_SHOW_SCORE, self::OPTION_SHOW_SCORE);
     }
     
     /**
@@ -93,21 +95,24 @@ class DeliveryExecutionFinderService extends ConfigurableService
      */
     public function getShowCorrectOption(LtiLaunchData $launchData): bool
     {
-        return $this->getBooleanOption($launchData, self::OPTION_SHOW_CORRECT);
+        return $this->getBooleanOption($launchData, self::LTI_SHOW_CORRECT, self::OPTION_SHOW_CORRECT);
     }
 
     /**
      * @param LtiLaunchData $launchData
+     * @param string $variable
      * @param string $option
      * @return bool
      * @throws LtiVariableMissingException
      */
-    protected function getBooleanOption(LtiLaunchData $launchData, string $option): bool
+    protected function getBooleanOption(LtiLaunchData $launchData, string $variable, string $option): bool
     {
-        $value = $launchData->hasVariable($option)
-            ? $launchData->getVariable($option)
+        $default = $this->hasOption($option)
+            ? $this->getOption($option)
             : false;
-
+        $value = $launchData->hasVariable($variable)
+            ? $launchData->getVariable($variable)
+            : $default;
         return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -69,5 +69,17 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->skip('0.6.0', '1.11.0');
+
+        if ($this->isVersion('1.11.0')) {
+
+            $serviceManager = $this->getServiceManager();
+
+            $serviceManager->register(DeliveryExecutionFinderService::SERVICE_ID, new DeliveryExecutionFinderService([
+                DeliveryExecutionFinderService::OPTION_SHOW_CORRECT => false,
+                DeliveryExecutionFinderService::OPTION_SHOW_SCORE => false
+            ]));
+
+            $this->setVersion('1.12.0');
+        }
     }
 }

--- a/test/unit/model/DeliveryExecutionFinderServiceTest.php
+++ b/test/unit/model/DeliveryExecutionFinderServiceTest.php
@@ -143,16 +143,27 @@ class DeliveryExecutionFinderServiceTest extends TestCase
     {
         $sourceId = 'v5ba19e6ltos1lmljfv8fgnb07:::S3294476:::29123:::dyJ86SiwwA9';
 
+        // check option passed through LTI
         $launchData = new LtiLaunchData(
             [
                 DeliveryExecutionFinderService::LTI_SOURCE_ID => $sourceId,
-                DeliveryExecutionFinderService::OPTION_SHOW_SCORE => $value
+                DeliveryExecutionFinderService::LTI_SHOW_SCORE => $value
             ],
             []
         );
 
+        $result = $this->subject->getShowScoreOption($launchData);
 
-        /** @var DeliveryExecution $deliveryExecution */
+        $this->assertEquals($expected, $result);
+
+        // check default option value
+        $launchData = new LtiLaunchData(
+            [DeliveryExecutionFinderService::LTI_SOURCE_ID => $sourceId],
+            []
+        );
+
+        $this->subject->setOption(DeliveryExecutionFinderService::OPTION_SHOW_SCORE, $value);
+
         $result = $this->subject->getShowScoreOption($launchData);
 
         $this->assertEquals($expected, $result);
@@ -168,16 +179,27 @@ class DeliveryExecutionFinderServiceTest extends TestCase
     {
         $sourceId = 'v5ba19e6ltos1lmljfv8fgnb07:::S3294476:::29123:::dyJ86SiwwA9';
 
+        // check option passed through LTI
         $launchData = new LtiLaunchData(
             [
                 DeliveryExecutionFinderService::LTI_SOURCE_ID => $sourceId,
-                DeliveryExecutionFinderService::OPTION_SHOW_CORRECT => $value
+                DeliveryExecutionFinderService::LTI_SHOW_CORRECT => $value
             ],
             []
         );
 
+        $result = $this->subject->getShowCorrectOption($launchData);
 
-        /** @var DeliveryExecution $deliveryExecution */
+        $this->assertEquals($expected, $result);
+
+        // check default option value
+        $launchData = new LtiLaunchData(
+            [DeliveryExecutionFinderService::LTI_SOURCE_ID => $sourceId],
+            []
+        );
+
+        $this->subject->setOption(DeliveryExecutionFinderService::OPTION_SHOW_CORRECT, $value);
+
         $result = $this->subject->getShowCorrectOption($launchData);
 
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9038

Add platform options for the LTI custom parameters controlling the disclosure of the scores and the correct responses.

Impacted unit test: `ltiTestReview/test/unit/model/DeliveryExecutionFinderServiceTest.php`

Platform options available in the config file `ltiTestReview/config/default/DeliveryExecutionFinderService.conf.php`:
```php
return new \oat\ltiTestReview\models\DeliveryExecutionFinderService([
    'show_score' => false,
    'show_correct' => false
]);
```