### PR TITLE
Fix/tao 8942/filter responses data

### DIFF
--- a/controller/Review.php
+++ b/controller/Review.php
@@ -140,10 +140,17 @@ class Review extends tao_actions_SinglePageModule
         if (!empty($itemData['data']['responses'])
             && $finder->getShowCorrectOption($this->ltiSession->getLaunchData())
         ) {
-            $itemData['data']['responses'] = array_merge_recursive(...[
+            $responsesData = array_merge_recursive(...[
                 $itemData['data']['responses'],
                 $itemPreviewer->loadCompiledItemVariables()
             ]);
+
+            // make sure the responses data are compliant to QTI definition
+            $responsesData = array_filter($responsesData, static function ($key) use ($responsesData) {
+                return array_key_exists('qtiClass', $responsesData) && array_key_exists('serial', $responsesData);
+            }, ARRAY_FILTER_USE_KEY);
+
+            $itemData['data']['responses'] = $responsesData;
         }
 
         $response['content'] = $itemData;

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'Test Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.12.0',
+    'version' => '1.12.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -81,5 +81,7 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('1.12.0');
         }
+
+        $this->skip('1.12.0', '1.12.1');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8942

Requires: 
 - [x] https://github.com/oat-sa/extension-tao-testqti-previewer/pull/37

Move the responses data filtering into the `getItem` endpoint. The reason why is we need all the consolidated data in order to properly discard incompatible entries.