### PR TITLE
Fix/tao 8942/error in filter for responses data

### DIFF
--- a/controller/Review.php
+++ b/controller/Review.php
@@ -146,11 +146,9 @@ class Review extends tao_actions_SinglePageModule
             ]);
 
             // make sure the responses data are compliant to QTI definition
-            $responsesData = array_filter($responsesData, static function ($key) use ($responsesData) {
-                return array_key_exists('qtiClass', $responsesData) && array_key_exists('serial', $responsesData);
+            $itemData['data']['responses'] = array_filter($responsesData, static function ($key) use ($responsesData) {
+                return array_key_exists('qtiClass', $responsesData[$key]) && array_key_exists('serial', $responsesData[$key]);
             }, ARRAY_FILTER_USE_KEY);
-
-            $itemData['data']['responses'] = $responsesData;
         }
 
         $response['content'] = $itemData;

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'Test Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.12.1',
+    'version' => '1.12.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -82,6 +82,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.12.0');
         }
 
-        $this->skip('1.12.0', '1.12.1');
+        $this->skip('1.12.0', '1.12.2');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8942

An error was on the filtering for responses data. The returned responses were emptied because the filter condition was not targeting the right context.