### PR TITLE
Require taoProctoring due to usage of functions from this extension

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,14 +29,15 @@ return [
     'label' => 'Test Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.12.2',
+    'version' => '1.13.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',
         'taoLti' => '>=10.1.0',
         'ltiDeliveryProvider' => '>=9.2.0',
         'taoQtiTest' => '>=34.6.0',
-        'taoQtiTestPreviewer' => '>=2.8.0'
+        'taoQtiTestPreviewer' => '>=2.8.0',
+        'taoProctoring' => '>=17.3.1'
     ],
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#ltiTestReviewManager',
     'acl' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -82,6 +82,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.12.0');
         }
 
-        $this->skip('1.12.0', '1.12.2');
+        $this->skip('1.12.0', '1.13.0');
     }
 }


### PR DESCRIPTION
If taoProctring is not installed usage of ltiTestReview will raise 500 error due to service not found. 
This update requires taoProctoring during installation of ltiTestReview extension.