### PR TITLE
Avoid notices when scores not provided

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'Test Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.15.1',
+    'version' => '1.15.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',

--- a/models/QtiRunnerInitDataBuilder.php
+++ b/models/QtiRunnerInitDataBuilder.php
@@ -190,8 +190,8 @@ class QtiRunnerInitDataBuilder
                         'categories' => [],
                         'informational' => $isInformational,
                         'skipped' => $isSkipped,
-                        'score' => $itemsStates[$itemId]['score'],
-                        'maxScore' => $itemsStates[$itemId]['maxScore']
+                        'score' => $itemsStates[$itemId]['score'] ?? null,
+                        'maxScore' => $itemsStates[$itemId]['maxScore'] ?? null
                     ];
 
                     $this->fillItemsData($itemId, $item->getHref(), $itemData['data']);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -82,6 +82,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.12.0');
         }
 
-        $this->skip('1.12.0', '1.15.1');
+        $this->skip('1.12.0', '1.15.2');
     }
 }


### PR DESCRIPTION
Without the fix, it brokes FE when showing notices enabled in PHP. It happens when custom parameters about showing scores (custom_show_score) set to false because in this case score and max score not provided. By default custom parameters are set as false. 