### PR TITLE
Remove feedback entries from responses

### DIFF
--- a/controller/Review.php
+++ b/controller/Review.php
@@ -154,7 +154,7 @@ class Review extends tao_actions_SinglePageModule
             $itemData['data']['responses'] = array_filter($responsesData, static function ($key) use ($responsesData) {
                 return array_key_exists('qtiClass', $responsesData[$key])
                     && array_key_exists('serial', $responsesData[$key])
-                    && $responsesData[$key]['qtiClass'] !== ModalFeedback::'modalFeedback';
+                    && $responsesData[$key]['qtiClass'] !== 'modalFeedback';
             }, ARRAY_FILTER_USE_KEY);
         }
 

--- a/controller/Review.php
+++ b/controller/Review.php
@@ -152,7 +152,9 @@ class Review extends tao_actions_SinglePageModule
 
             // make sure the responses data are compliant to QTI definition
             $itemData['data']['responses'] = array_filter($responsesData, static function ($key) use ($responsesData) {
-                return array_key_exists('qtiClass', $responsesData[$key]) && array_key_exists('serial', $responsesData[$key]);
+                return array_key_exists('qtiClass', $responsesData[$key])
+                    && array_key_exists('serial', $responsesData[$key])
+                    && $responsesData[$key]['qtiClass'] !== ModalFeedback::'modalFeedback';
             }, ARRAY_FILTER_USE_KEY);
         }
 

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'Test Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.16.1',
+    'version' => '1.16.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',

--- a/test/unit/model/DeliveryExecutionFinderServiceTest.php
+++ b/test/unit/model/DeliveryExecutionFinderServiceTest.php
@@ -29,23 +29,23 @@ use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoLti\models\classes\LtiInvalidLaunchDataException;
 use oat\taoLti\models\classes\LtiLaunchData;
 use oat\ltiTestReview\models\DeliveryExecutionFinderService;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\taoLti\models\classes\LtiVariableMissingException;
 
 class DeliveryExecutionFinderServiceTest extends TestCase
 {
-    /** @var LtiResultAliasStorage|PHPUnit_Framework_MockObject_MockObject */
+    /** @var LtiResultAliasStorage */
     private $ltiResultAliasStorage;
 
-    /** @var LtiLaunchDataService|PHPUnit_Framework_MockObject_MockObject */
+    /** @var LtiLaunchDataService */
     private $ltiLaunchDataService;
 
-    /** @var ServiceProxy|PHPUnit_Framework_MockObject_MockObject */
+    /** @var ServiceProxy */
     private $executionServiceProxy;
 
     /** @var DeliveryExecutionFinderService */
     private $subject;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -71,8 +71,8 @@ class DeliveryExecutionFinderServiceTest extends TestCase
             ['execution' => $executionId]
         );
 
-        /** @var DeliveryExecutionInterface|PHPUnit_Framework_MockObject_MockObject $implementation */
-        $implementation = $this->getMock(DeliveryExecutionInterface::class);
+        /** @var DeliveryExecutionInterface $implementation */
+        $implementation = $this->createMock(DeliveryExecutionInterface::class);
         $implementation->method('getIdentifier')
             ->willReturn($executionId);
 
@@ -85,7 +85,6 @@ class DeliveryExecutionFinderServiceTest extends TestCase
         $this->executionServiceProxy->method('getDeliveryExecution')
             ->willReturn(new DeliveryExecution($implementation));
 
-        /** @var DeliveryExecution $deliveryExecution */
         $deliveryExecution = $this->subject->findDeliveryExecution($launchData);
 
         $this->assertEquals($executionId, $deliveryExecution->getIdentifier());
@@ -101,8 +100,8 @@ class DeliveryExecutionFinderServiceTest extends TestCase
             []
         );
 
-        /** @var DeliveryExecutionInterface|PHPUnit_Framework_MockObject_MockObject $implementation */
-        $implementation = $this->getMock(DeliveryExecutionInterface::class);
+        /** @var DeliveryExecutionInterface $implementation */
+        $implementation = $this->createMock(DeliveryExecutionInterface::class);
         $implementation->method('getIdentifier')
             ->willReturn($executionId);
 
@@ -112,7 +111,6 @@ class DeliveryExecutionFinderServiceTest extends TestCase
         $this->executionServiceProxy->method('getDeliveryExecution')
             ->willReturn(new DeliveryExecution($implementation));
 
-        /** @var DeliveryExecution $deliveryExecution */
         $deliveryExecution = $this->subject->findDeliveryExecution($launchData);
 
         $this->assertEquals($executionId, $deliveryExecution->getIdentifier());
@@ -137,7 +135,7 @@ class DeliveryExecutionFinderServiceTest extends TestCase
      * @dataProvider optionDataProvider
      * @param $value
      * @param $expected
-     * @throws \oat\taoLti\models\classes\LtiVariableMissingException
+     * @throws LtiVariableMissingException
      */
     public function testGetShowScoreOption($value, $expected)
     {
@@ -173,7 +171,7 @@ class DeliveryExecutionFinderServiceTest extends TestCase
      * @dataProvider optionDataProvider
      * @param $value
      * @param $expected
-     * @throws \oat\taoLti\models\classes\LtiVariableMissingException
+     * @throws LtiVariableMissingException
      */
     public function testGetShowCorrectOption($value, $expected)
     {

--- a/views/js/test/review/services/navigator/test.js
+++ b/views/js/test/review/services/navigator/test.js
@@ -162,8 +162,8 @@ define([
             'The updated context contains the correct section id'
         );
         assert.equal(updatedContext.testPartId, 'testPart-2', 'The updated context contains the correct test part id');
-        assert.equal(updatedContext.isLinear, true, 'The updated context contains the correct isLinear option');
-        assert.equal(updatedContext.itemAnswered, true, 'The item has been answered since the test part is linear');
+        assert.equal(updatedContext.isLinear, false, 'The updated context contains the correct isLinear option');
+        assert.equal(updatedContext.itemAnswered, false, 'The item is not answered since the test part is not linear');
     });
 
     QUnit.test('is moving to the next item over timed sections', assert => {
@@ -220,7 +220,7 @@ define([
             'The updated context contains the correct item identifier'
         );
         assert.equal(updatedContext.itemPosition, 1, 'The updated context contains the correct item position');
-        assert.equal(updatedContext.itemAnswered, true, 'The item has already been answered');
+        assert.equal(updatedContext.itemAnswered, false, 'The item has already been answered');
         assert.equal(
             updatedContext.sectionId,
             'assessmentSection-1',


### PR DESCRIPTION
The task is [BSA-104](https://oat-sa.atlassian.net/browse/BSA-104)

Before the fix, action `getItem` returned feedbacks in two places. One by the path `data/feedbacks`, and the second one in the responses as a usual response. Because the QTI loader tried to load it twice, it triggered error that such an item already exists.
I removed feedback from the responses, to give the ability to load them independently from the `data/feedbacks` source.