### PR TITLE
Feature TBD-45 do not perform csrf token validation on get request handling

### DIFF
--- a/controller/Review.php
+++ b/controller/Review.php
@@ -27,6 +27,8 @@ use common_exception_NotFound;
 use core_kernel_users_GenerisUser;
 use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyAwareTrait;
+use oat\ltiTestReview\models\DeliveryExecutionFinderService;
+use oat\ltiTestReview\models\QtiRunnerInitDataBuilderFactory;
 use oat\tao\model\http\HttpJsonResponseTrait;
 use oat\tao\model\mvc\DefaultUrlService;
 use oat\taoLti\models\classes\LtiException;
@@ -37,8 +39,6 @@ use oat\taoLti\models\classes\TaoLtiSession;
 use oat\taoProctoring\model\execution\DeliveryExecutionManagerService;
 use oat\taoQtiTestPreviewer\models\ItemPreviewer;
 use oat\taoResultServer\models\classes\ResultServerService;
-use oat\ltiTestReview\models\DeliveryExecutionFinderService;
-use oat\ltiTestReview\models\QtiRunnerInitDataBuilderFactory;
 use tao_actions_SinglePageModule;
 
 /**
@@ -95,8 +95,6 @@ class Review extends tao_actions_SinglePageModule
      */
     public function init(): void
     {
-        $this->validateCsrf();
-
         /** @var QtiRunnerInitDataBuilderFactory $dataBuilder */
         $dataBuilder = $this->getServiceLocator()->get(QtiRunnerInitDataBuilderFactory::SERVICE_ID);
 
@@ -118,8 +116,6 @@ class Review extends tao_actions_SinglePageModule
      */
     public function getItem(): void
     {
-        $this->validateCsrf();
-
         $params = $this->getPsrRequest()->getQueryParams();
 
         $deliveryExecutionId = $params['serviceCallId'];

--- a/manifest.php
+++ b/manifest.php
@@ -17,19 +17,19 @@
  * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
  */
 
-use oat\tao\model\accessControl\func\AccessRule;
-use oat\tao\model\user\TaoRoles;
-use oat\taoLti\models\classes\LtiRoles;
 use oat\ltiTestReview\controller\Review;
 use oat\ltiTestReview\controller\ReviewTool;
 use oat\ltiTestReview\scripts\update\Updater;
+use oat\tao\model\accessControl\func\AccessRule;
+use oat\tao\model\user\TaoRoles;
+use oat\taoLti\models\classes\LtiRoles;
 
 return [
     'name' => 'ltiTestReview',
     'label' => 'Test Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.16.2',
+    'version' => '1.17.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',

--- a/views/js/review/proxy/qtiTestReviewProxy.js
+++ b/views/js/review/proxy/qtiTestReviewProxy.js
@@ -99,7 +99,7 @@ define([
             this.configStorage = configFactory(config || {});
 
             // request for initialization
-            return this.request(this.configStorage.getTestActionUrl('init'), params);
+            return this.request(this.configStorage.getTestActionUrl('init'), params, void 0, true);
         },
 
         /**
@@ -147,7 +147,7 @@ define([
          *                      Any error will be provided if rejected.
          */
         getItem(itemIdentifier, params) {
-            return this.request(this.configStorage.getItemActionUrl(itemIdentifier, 'getItem'), params);
+            return this.request(this.configStorage.getItemActionUrl(itemIdentifier, 'getItem'), params, void 0, true);
         },
 
         /**

--- a/views/js/test/review/proxy/qtiTestReviewProxy/test.js
+++ b/views/js/test/review/proxy/qtiTestReviewProxy/test.js
@@ -69,8 +69,6 @@ define([
 
     QUnit.cases.init([{
         title: 'success',
-        sendToken: '1234',
-        receiveToken: '4567',
         response: {
             success: true
         },
@@ -78,8 +76,6 @@ define([
         success: true
     }, {
         title: 'failing data',
-        sendToken: '1234',
-        receiveToken: '4567',
         response: {
             errorCode: 1,
             errorMessage: 'oops',
@@ -89,8 +85,6 @@ define([
         success: false
     }, {
         title: 'failing request',
-        sendToken: '1234',
-        receiveToken: '4567',
         response: 'error',
         ajaxSuccess: false,
         success: false
@@ -115,9 +109,6 @@ define([
         $.mockjax({
             url: '/*',
             status: caseData.ajaxSuccess ? 200 : 500,
-            headers: {
-                'X-CSRF-Token': caseData.receiveToken
-            },
             responseText: caseData.response,
             response(settings) {
                 assert.equal(settings.url, expectedUrl, 'The proxy has called the right service');
@@ -126,11 +117,12 @@ define([
 
         const proxy = proxyFactory('testProxy', initConfig);
         const tokenHandler = proxy.getTokenHandler();
+        const tokenValue = 'test';
 
         proxy
             .install()
             .then(() => tokenHandler.clearStore())
-            .then(() => proxy.getTokenHandler().setToken(caseData.sendToken))
+            .then(() => proxy.getTokenHandler().setToken(tokenValue))
             .then(() => {
                 proxy.on('init', (promise, config) => {
                     assert.ok(true, 'The proxy has fired the "init" event');
@@ -155,7 +147,7 @@ define([
                 assert.ok(!caseData.success, `The proxy has thrown an error! #${err}`);
             })
             .then(() => proxy.getTokenHandler().getToken().then(token => {
-                assert.equal(token, caseData.receiveToken, 'The proxy must update the security token');
+                assert.equal(token, tokenValue, 'The proxy must not use the security token');
             }))
             .then(ready);
     });
@@ -349,8 +341,6 @@ define([
     QUnit.cases.init([{
         title: 'success',
         uri: 'http://tao.dev/mockItemDefinition#123',
-        sendToken: '1234',
-        receiveToken: '4567',
         response: {
             itemData: {
                 interactions: [{}]
@@ -365,8 +355,6 @@ define([
     }, {
         title: 'failing data',
         uri: 'http://tao.dev/mockItemDefinition#123',
-        sendToken: '1234',
-        receiveToken: '4567',
         response: {
             errorCode: 1,
             errorMessage: 'oops',
@@ -377,8 +365,6 @@ define([
     }, {
         title: 'failing request',
         uri: 'http://tao.dev/mockItemDefinition#123',
-        sendToken: '1234',
-        receiveToken: '4567',
         response: 'error',
         ajaxSuccess: false,
         success: false
@@ -404,9 +390,6 @@ define([
         $.mockjax([{
             url: '/init*',
             status: 200,
-            headers: {
-                'X-CSRF-Token': caseData.receiveToken
-            },
             responseText: {
                 success: true
             }
@@ -424,11 +407,12 @@ define([
 
         const proxy = proxyFactory('testProxy', initConfig);
         const tokenHandler = proxy.getTokenHandler();
+        const tokenValue = 'test';
 
         proxy
             .install()
             .then(() => tokenHandler.clearStore())
-            .then(() => proxy.getTokenHandler().setToken(caseData.sendToken))
+            .then(() => proxy.getTokenHandler().setToken(tokenValue))
             .then(() => proxy.getItem(caseData.uri))
             .then(() => {
                 assert.ok(false, 'The proxy must be initialized');
@@ -461,7 +445,7 @@ define([
                 assert.ok(!caseData.success, `The proxy has thrown an error! #${err}`);
             })
             .then(() => proxy.getTokenHandler().getToken().then(token => {
-                assert.equal(token, caseData.receiveToken, 'The proxy must update the security token');
+                assert.equal(token, tokenValue, 'The proxy must not use the security token');
             }))
             .then(ready);
     });


### PR DESCRIPTION
- [TBD-45](https://oat-sa.atlassian.net/browse/TBD-45) feat: stop verifying a request CSRF token upon handling requests, retrieving review items
- [TBD-45](https://oat-sa.atlassian.net/browse/TBD-45) feat: stop sending CSRF tokens to GET review item request handlers
- [TBD-45](https://oat-sa.atlassian.net/browse/TBD-45) chore(version): bump a minor one