### PR TITLE
feat: added new endpoint for LTI1p3 review mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "oat-sa/generis" : ">=14.0.0",
     "oat-sa/tao-core" : ">=47.0.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
-    "oat-sa/extension-tao-lti" : ">=12.0.0",
+    "oat-sa/extension-tao-lti" : ">=13.2.0",
     "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
     "oat-sa/extension-lti-outcomeui" : ">=1.0.0",
     "oat-sa/extension-tao-proctoring" : ">=20.0.0",

--- a/controller/ReviewTool.php
+++ b/controller/ReviewTool.php
@@ -22,6 +22,7 @@ namespace oat\ltiTestReview\controller;
 use oat\taoLti\controller\ToolModule;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
+use oat\taoLti\models\classes\LtiService;
 
 /**
  * ReviewTool controller for managing LTI calls, used as entry point for LTI call and do redirect to proper application controller
@@ -44,5 +45,13 @@ class ReviewTool extends ToolModule
                 LtiErrorMessage::ERROR_UNAUTHORIZED
             );
         }
+    }
+
+    public function launch1p3(): void
+    {
+        $message = $this->getValidatedLtiMessagePayload();
+
+        LtiService::singleton()->startLti1p3Session($message);
+        $this->forward('run', null, null, $_GET);
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -35,6 +35,7 @@ return [
         [AccessRule::GRANT, 'http://www.tao.lu/Ontologies/generis.rdf#ltiTestReviewManager', ['ext' => 'ltiTestReview']],
         [AccessRule::GRANT, TaoRoles::ANONYMOUS, ReviewTool::class],
         [AccessRule::GRANT, LtiRoles::CONTEXT_LEARNER, Review::class],
+        [AccessRule::GRANT, LtiRoles::CONTEXT_LTI1P3_LEARNER, Review::class]
     ],
     'install' => [
         'php' => [],

--- a/migrations/Version2021092101_ltiTestReview.php
+++ b/migrations/Version2021092101_ltiTestReview.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\ltiTestReview\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\ltiTestReview\controller\Review;
+use oat\tao\model\accessControl\func\AccessRule;
+use oat\tao\model\accessControl\func\AclProxy;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoLti\models\classes\LtiRoles;
+
+final class Version2021092101_ltiTestReview extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Allow LTI1p3 Learner using Review module';
+    }
+
+    public function up(Schema $schema): void
+    {
+        AclProxy::applyRule($this->getRule());
+    }
+
+    public function down(Schema $schema): void
+    {
+        AclProxy::revokeRule($this->getRule());
+    }
+
+    private function getRule(): AccessRule
+    {
+        return new AccessRule(AccessRule::GRANT, LtiRoles::CONTEXT_LTI1P3_LEARNER, Review::class);
+    }
+}


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1910

Need to merge it first https://github.com/oat-sa/extension-tao-lti/pull/305

Need to provide delivery execution id in custom claims.

Example for NG stack.

Launch URL: `http://backoffice.docker.localhost/ltiTestReview/ReviewTool/launch1p3`

```
{
    "https://purl.imsglobal.org/spec/lti/claim/roles": [
        "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"
    ],
    "https://purl.imsglobal.org/spec/lti/claim/custom": {
        "execution": "http://backoffice.docker.localhost/ontologies/tao.rdf#i6149ccf3252db7e59ff53bc7c1bcfc",
        "custom_show_score": "true",
        "custom_show_correct": "true"
    }
}
```

DevKit Link

http://lti.docker.localhost/platform/message/launch/lti-resource-link?registration=devkitToTAO&user_list=c3po&launch_url=http://backoffice.docker.localhost/ltiTestReview/ReviewTool/launch1p3&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D,%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/custom%22:%20%7B%0D%0A%20%20%20%20%20%20%20%20%22execution%22:%20%22http://backoffice.docker.localhost/ontologies/tao.rdf%23i6149ccf3252db7e59ff53bc7c1bcfc%22,%0D%0A%20%20%20%20%20%20%20%20%22custom_show_score%22:%20%22true%22,%0D%0A%20%20%20%20%20%20%20%20%22custom_show_correct%22:%20%22true%22%0D%0A%20%20%20%20%7D%0D%0A%7D
