### PR TITLE
fix: remove oat-sa/extension-lti-outcomeui dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
     "oat-sa/extension-tao-lti" : ">=13.2.0",
     "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
-    "oat-sa/extension-lti-outcomeui" : ">=1.0.0",
     "oat-sa/extension-tao-proctoring" : ">=20.0.0",
     "oat-sa/extension-tao-testqti" : ">=41.0.0",
     "oat-sa/extension-tao-outcome" : ">=13.0.0",


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-1966

**extension-lti-outcomeui was deleted**

How to test it

1. Install [Bosa's composer.json packages](https://github.com/oat-sa/tao-enterprise-bosa/blob/v0.148.2-alpha/composer.json)
2. Run taoSetup (docker exec -it nextgen_tao_phpfpm php tao/scripts/taoSetup.php setup.json -vvv)
3. Install ltiTestReview in the backoffice
4. Install [the next composer's packages](https://github.com/oat-sa/extension-lti-test-review/files/7253284/composer.zip) (including repositories) 
5. Run taoUpdate (php tao/scripts/taoUpdate.php (inside nextgen_tao_phpfpm container ) )

