### PR TITLE
[Backport] fix: oat-sa/extension-lti-outcomeui was deleted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
     "oat-sa/extension-tao-lti" : ">=12.0.0",
     "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
-    "oat-sa/extension-lti-outcomeui" : ">=1.0.0",
     "oat-sa/extension-tao-proctoring" : ">=20.0.0",
     "oat-sa/extension-tao-testqti" : ">=41.0.0",
     "oat-sa/extension-tao-outcome" : ">=13.0.0",


### PR DESCRIPTION
For https://oat-sa.atlassian.net/browse/TR-2381

Backport onto new v2.0.2 for `tao-community 2021.10.2`:
- #89 