### PR TITLE
Feature/tr 1919/lti submission review request

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ User id should be provided by usage `for_user` claim
 
 ```json
 {
+  "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiSubmissionReviewRequest"
   "https://purl.imsglobal.org/spec/lti/claim/for_user": {
     "user_id": "<string>"
   }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,38 @@ To run review of specific delivery execution use the next endpoint:
 https://YOUR_DOMAIN/ltiTestReview/ReviewTool/launch?execution=YOUR_DELIVERY_EXECUTION_URI
 ```
 
-Endpoint without `execution` parameter (`https://YOUR_DOMAIN/ltiTestReview/ReviewTool/launch`) will use `lis_result_sourcedid` field from lauch data to determine delivery execution.
+Endpoint without `execution` parameter (`https://YOUR_DOMAIN/ltiTestReview/ReviewTool/launch`) will use `lis_result_sourcedid` field from launch data to determine delivery execution.
+
+To run review of the latest delivery execution for user use next endpoint:
+
+```
+https://YOUR_DOMAIN/ltiTestReview/ReviewTool/launch1p3?delivery=YOUR_DELIVERY_URI
+```
+
+User id should be provided by usage `for_user` claim
+
+```json
+{
+  "https://purl.imsglobal.org/spec/lti/claim/for_user": {
+    "user_id": "<string>"
+  }
+}
+```
+As backward compatibility this endpoint allows run exact delivery execution,
+which id must be provided in custom claim set. 
+
+```
+https://YOUR_DOMAIN/ltiTestReview/ReviewTool/launch1p3
+```
+```json
+{
+  "https://purl.imsglobal.org/spec/lti/claim/custom": {
+    "execution": "<deliery_excution_id>"
+  }
+}
+```
+
+
 
 ### LTI options
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "oat-sa/generis" : ">=14.0.0",
     "oat-sa/tao-core" : ">=48.39.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
-    "oat-sa/extension-tao-lti" : ">=13.2.0",
+    "oat-sa/extension-tao-lti" : "dev-feature/TR-1919/LtiSubmissionReviewRequest as 100",
     "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
     "oat-sa/extension-tao-proctoring" : ">=20.0.0",
     "oat-sa/extension-tao-testqti" : ">=41.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
     "oat-sa/extension-tao-ltideliveryprovider" : ">=12.0.0",
     "oat-sa/generis" : ">=14.0.0",
-    "oat-sa/tao-core" : ">=47.0.0",
+    "oat-sa/tao-core" : ">=48.39.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
     "oat-sa/extension-tao-lti" : ">=13.2.0",
     "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "oat-sa/generis" : ">=14.0.0",
     "oat-sa/tao-core" : ">=48.39.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
-    "oat-sa/extension-tao-lti" : "dev-feature/TR-1919/LtiSubmissionReviewRequest as 100",
+    "oat-sa/extension-tao-lti" : ">=15.3.0",
     "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
     "oat-sa/extension-tao-proctoring" : ">=20.0.0",
     "oat-sa/extension-tao-testqti" : ">=41.0.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "oat-sa/generis" : ">=14.0.0",
     "oat-sa/tao-core" : ">=48.39.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
-    "oat-sa/extension-tao-lti" : ">=15.4.0",
+    "oat-sa/extension-tao-lti" : ">=15.4.1",
     "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
     "oat-sa/extension-tao-proctoring" : ">=20.0.0",
     "oat-sa/extension-tao-testqti" : ">=41.0.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "oat-sa/generis" : ">=14.0.0",
     "oat-sa/tao-core" : ">=48.39.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
-    "oat-sa/extension-tao-lti" : ">=15.3.0",
+    "oat-sa/extension-tao-lti" : ">=15.4.0",
     "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
     "oat-sa/extension-tao-proctoring" : ">=20.0.0",
     "oat-sa/extension-tao-testqti" : ">=41.0.0",

--- a/controller/Review.php
+++ b/controller/Review.php
@@ -127,10 +127,14 @@ class Review extends tao_actions_SinglePageModule
                     $finder->getShowScoreOption($this->ltiSession->getLaunchData())
                 );
             }
-            $this->setSuccessJsonResponse($data);
+            $this->returnJson($data);
         } catch (common_exception_ClientException $e) {
             $this->logError($e->getMessage());
-            $this->setErrorJsonResponse($e->getUserMessage(), $e->getCode());
+            $this->returnJson([
+                'success' => false,
+                'type' => 'error',
+                'message' => $e->getUserMessage()
+            ]);
         }
     }
 

--- a/controller/Review.php
+++ b/controller/Review.php
@@ -59,8 +59,6 @@ class Review extends tao_actions_SinglePageModule
     use OntologyAwareTrait;
     use HttpJsonResponseTrait;
 
-    private const LTI_1P3_VERSION = '1.3.0';
-
     /** @var TaoLtiSession */
     private $ltiSession;
 

--- a/controller/Review.php
+++ b/controller/Review.php
@@ -25,6 +25,7 @@ namespace oat\ltiTestReview\controller;
 use common_Exception;
 use common_exception_ClientException;
 use common_exception_Error;
+use common_exception_InconsistentData;
 use common_exception_NotFound;
 use common_exception_Unauthorized;
 use core_kernel_users_GenerisUser;
@@ -45,6 +46,7 @@ use oat\taoProctoring\model\execution\DeliveryExecutionManagerService;
 use oat\taoQtiTestPreviewer\models\ItemPreviewer;
 use oat\taoResultServer\models\classes\ResultServerService;
 use tao_actions_SinglePageModule;
+use taoResultServer_models_classes_ReadableResultStorage;
 
 /**
  * Review controller class thar provides data for js-application
@@ -142,7 +144,7 @@ class Review extends tao_actions_SinglePageModule
      * Provides the definition data and the state for a particular item
      *
      * @throws LtiVariableMissingException
-     * @throws \common_exception_InconsistentData
+     * @throws common_exception_InconsistentData
      * @throws common_Exception
      * @throws common_exception_Error
      * @throws common_exception_NotFound
@@ -213,7 +215,7 @@ class Review extends tao_actions_SinglePageModule
     {
         /** @var ResultServerService $resultServerService */
         $resultServerService = $this->getServiceLocator()->get(ResultServerService::SERVICE_ID);
-        /** @var \taoResultServer_models_classes_ReadableResultStorage $implementation */
+        /** @var taoResultServer_models_classes_ReadableResultStorage $implementation */
         $implementation = $resultServerService->getResultStorage();
 
         $testTaker = new core_kernel_users_GenerisUser($this->getResource($implementation->getTestTaker($resultId)));

--- a/controller/Review.php
+++ b/controller/Review.php
@@ -272,7 +272,7 @@ class Review extends tao_actions_SinglePageModule
     /**
      * @throws LtiVariableMissingException
      */
-    public function getUserId(): string
+    private function getUserId(): string
     {
         $userId = $this->ltiSession->getUserUri();
         if (

--- a/controller/Review.php
+++ b/controller/Review.php
@@ -31,6 +31,7 @@ use common_exception_Unauthorized;
 use core_kernel_users_GenerisUser;
 use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyAwareTrait;
+use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
 use oat\ltiTestReview\models\DeliveryExecutionFinderService;
 use oat\ltiTestReview\models\QtiRunnerInitDataBuilderFactory;
 use oat\tao\model\http\HttpJsonResponseTrait;
@@ -274,13 +275,11 @@ class Review extends tao_actions_SinglePageModule
      */
     private function getUserId(): string
     {
-        $userId = $this->ltiSession->getUserUri();
-        if (
-            $this->ltiSession->getLaunchData()->getVariable(LtiLaunchData::LTI_VERSION) === self::LTI_1P3_VERSION
-        ) {
-            $userId = $this->ltiSession->getLaunchData()->getLtiForUserId();
+        $messageType = $this->ltiSession->getLaunchData()->getVariable(LtiLaunchData::LTI_MESSAGE_TYPE);
+        if ($messageType === LtiMessageInterface::LTI_MESSAGE_TYPE_SUBMISSION_REVIEW_REQUEST) {
+            return $this->ltiSession->getLaunchData()->getLtiForUserId();
         }
 
-        return $userId;
+        return $this->ltiSession->getUserUri();
     }
 }

--- a/controller/ReviewTool.php
+++ b/controller/ReviewTool.php
@@ -19,6 +19,9 @@
 
 namespace oat\ltiTestReview\controller;
 
+use ActionEnforcingException;
+use common_exception_Error;
+use InterruptedActionException;
 use oat\taoLti\controller\ToolModule;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
@@ -32,13 +35,13 @@ class ReviewTool extends ToolModule
 {
     /**
      * @throws LtiException
-     * @throws \InterruptedActionException
-     * @throws \common_exception_Error
+     * @throws InterruptedActionException
+     * @throws common_exception_Error
      */
-    public function run()
+    public function run(): void
     {
         if ($this->hasAccess(Review::class, 'index')) {
-            $this->redirect(_url('index', 'Review'));
+            $this->redirect(_url('index', 'Review', null, $_GET));
         } else {
             throw new LtiException(
                 'You are not authorized to access this resource',
@@ -47,6 +50,11 @@ class ReviewTool extends ToolModule
         }
     }
 
+    /**
+     * @throws common_exception_Error
+     * @throws ActionEnforcingException
+     * @throws InterruptedActionException
+     */
     public function launch1p3(): void
     {
         $message = $this->getValidatedLtiMessagePayload();

--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,9 @@ return [
         [AccessRule::GRANT, 'http://www.tao.lu/Ontologies/generis.rdf#ltiTestReviewManager', ['ext' => 'ltiTestReview']],
         [AccessRule::GRANT, TaoRoles::ANONYMOUS, ReviewTool::class],
         [AccessRule::GRANT, LtiRoles::CONTEXT_LEARNER, Review::class],
-        [AccessRule::GRANT, LtiRoles::CONTEXT_LTI1P3_LEARNER, Review::class]
+        [AccessRule::GRANT, LtiRoles::CONTEXT_LTI1P3_LEARNER, Review::class],
+        [AccessRule::GRANT, LtiRoles::CONTEXT_LTI1P3_INSTRUCTOR, Review::class],
+        [AccessRule::GRANT, LtiRoles::CONTEXT_LTI1P3_MENTOR, Review::class]
     ],
     'install' => [
         'php' => [],

--- a/migrations/Version202111031413133291_ltiTestReview.php
+++ b/migrations/Version202111031413133291_ltiTestReview.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\ltiTestReview\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\ltiTestReview\controller\Review;
+use oat\tao\model\accessControl\func\AccessRule;
+use oat\tao\model\accessControl\func\AclProxy;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoLti\models\classes\LtiRoles;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202111031413133291_ltiTestReview extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Allow LTI1p3 Mentor and Instructor using Review module';
+    }
+
+    public function up(Schema $schema): void
+    {
+        AclProxy::applyRule($this->getMentorRule());
+        AclProxy::applyRule($this->getInstructorRule());
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        AclProxy::revokeRule($this->getMentorRule());
+        AclProxy::revokeRule($this->getInstructorRule());
+
+    }
+
+    private function getMentorRule(): AccessRule
+    {
+        return new AccessRule(AccessRule::GRANT, LtiRoles::CONTEXT_LTI1P3_MENTOR, Review::class);
+    }
+
+    private function getInstructorRule(): AccessRule
+    {
+        return new AccessRule(AccessRule::GRANT, LtiRoles::CONTEXT_LTI1P3_INSTRUCTOR, Review::class);
+    }
+}

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -93,8 +93,8 @@ class DeliveryExecutionFinderService extends ConfigurableService
             usort(
                 $userDeliveryExecutions,
                 static function (DeliveryExecution $executionA, DeliveryExecution $executionB) {
-                    $startStampA = tao_helpers_Date::getTimeStamp($executionA->getStartTime(),true);
-                    $startStampB = tao_helpers_Date::getTimeStamp($executionB->getStartTime(),true);
+                    $startStampA = tao_helpers_Date::getTimeStamp($executionA->getStartTime(), true);
+                    $startStampB = tao_helpers_Date::getTimeStamp($executionB->getStartTime(), true);
 
                     return (float) $startStampA <=> (float) $startStampB;
 

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -20,6 +20,7 @@
 namespace oat\ltiTestReview\models;
 
 use core_kernel_classes_Resource;
+use oat\dtms\DateTime;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
 use oat\ltiDeliveryProvider\model\LtiResultAliasStorage;
 use oat\oatbox\service\ConfigurableService;
@@ -80,8 +81,10 @@ class DeliveryExecutionFinderService extends ConfigurableService
      * @throws LtiVariableMissingException
      * @throws \common_exception_Error
      */
-    public function findByUserAndDelivery(LtiLaunchData $ltiLaunchData, string $deliveryId): ?DeliveryExecution
-    {
+    public function findLastExecutionByUserAndDelivery(
+        LtiLaunchData $ltiLaunchData,
+        string $deliveryId
+    ): ?DeliveryExecution {
         $deliveryExecutionService = $this->getExecutionServiceProxy();
         $deliveryResource = new core_kernel_classes_Resource($deliveryId);
         $userDeliveryExecutions = $deliveryExecutionService->getUserExecutions(
@@ -90,6 +93,13 @@ class DeliveryExecutionFinderService extends ConfigurableService
         );
 
         if (count($userDeliveryExecutions) > 0) {
+            usort(
+                $userDeliveryExecutions,
+                static function (DeliveryExecution $executionA, DeliveryExecution $executionB) {
+                    return new DateTime($executionA->getStartTime()) <=> new DateTime($executionB->getStartTime());
+                }
+            );
+
             return end($userDeliveryExecutions);
         }
 

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -19,6 +19,8 @@
 
 namespace oat\ltiTestReview\models;
 
+use common_exception_Error;
+use common_exception_NotFound;
 use core_kernel_classes_Resource;
 use oat\dtms\DateTime;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
@@ -30,6 +32,7 @@ use oat\taoDelivery\model\execution\ServiceProxy as ExecutionServiceProxy;
 use oat\taoLti\models\classes\LtiInvalidLaunchDataException;
 use oat\taoLti\models\classes\LtiLaunchData;
 use oat\taoLti\models\classes\LtiVariableMissingException;
+use tao_helpers_Date;
 
 /**
  * Find delivery execution
@@ -79,7 +82,8 @@ class DeliveryExecutionFinderService extends ConfigurableService
 
     /**
      * @throws LtiVariableMissingException
-     * @throws \common_exception_Error
+     * @throws common_exception_Error
+     * @throws common_exception_NotFound
      */
     public function findLastExecutionByUserAndDelivery(
         LtiLaunchData $ltiLaunchData,
@@ -96,7 +100,11 @@ class DeliveryExecutionFinderService extends ConfigurableService
             usort(
                 $userDeliveryExecutions,
                 static function (DeliveryExecution $executionA, DeliveryExecution $executionB) {
-                    return new DateTime($executionA->getStartTime()) <=> new DateTime($executionB->getStartTime());
+                    $startStampA = tao_helpers_Date::getTimeStamp($executionA->getStartTime(),true);
+                    $startStampB = tao_helpers_Date::getTimeStamp($executionB->getStartTime(),true);
+
+                    return (float) $startStampA <=> (float) $startStampB;
+
                 }
             );
 

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -22,7 +22,6 @@ namespace oat\ltiTestReview\models;
 use common_exception_Error;
 use common_exception_NotFound;
 use core_kernel_classes_Resource;
-use oat\dtms\DateTime;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
 use oat\ltiDeliveryProvider\model\LtiResultAliasStorage;
 use oat\oatbox\service\ConfigurableService;
@@ -81,20 +80,14 @@ class DeliveryExecutionFinderService extends ConfigurableService
     }
 
     /**
-     * @throws LtiVariableMissingException
      * @throws common_exception_Error
      * @throws common_exception_NotFound
      */
-    public function findLastExecutionByUserAndDelivery(
-        LtiLaunchData $ltiLaunchData,
-        string $deliveryId
-    ): ?DeliveryExecution {
+    public function findLastExecutionByUserAndDelivery(string $userId, string $deliveryId): ?DeliveryExecution
+    {
         $deliveryExecutionService = $this->getExecutionServiceProxy();
         $deliveryResource = new core_kernel_classes_Resource($deliveryId);
-        $userDeliveryExecutions = $deliveryExecutionService->getUserExecutions(
-            $deliveryResource,
-            $ltiLaunchData->getUserID()
-        );
+        $userDeliveryExecutions = $deliveryExecutionService->getUserExecutions($deliveryResource, $userId);
 
         if (count($userDeliveryExecutions) > 0) {
             usort(

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -77,6 +77,26 @@ class DeliveryExecutionFinderService extends ConfigurableService
     }
 
     /**
+     * @throws LtiVariableMissingException
+     * @throws \common_exception_Error
+     */
+    public function findByUserAndDelivery(LtiLaunchData $ltiLaunchData, string $deliveryId): ?DeliveryExecution
+    {
+        $deliveryExecutionService = $this->getExecutionServiceProxy();
+        $deliveryResource = new core_kernel_classes_Resource($deliveryId);
+        $userDeliveryExecutions = $deliveryExecutionService->getUserExecutions(
+            $deliveryResource,
+            $ltiLaunchData->getUserID()
+        );
+
+        if (count($userDeliveryExecutions) > 0) {
+            return end($userDeliveryExecutions);
+        }
+
+        return null;
+    }
+
+    /**
      * @param LtiLaunchData $launchData
      *
      * @return bool

--- a/test/unit/model/DeliveryExecutionFinderServiceTest.php
+++ b/test/unit/model/DeliveryExecutionFinderServiceTest.php
@@ -122,8 +122,7 @@ class DeliveryExecutionFinderServiceTest extends TestCase
         $deliveryId = 'http://backoffice.docker.localhost/ontologies/tao.rdf#i617822471ea2d126631ac77e4b86e48';
 
         $this->executionServiceProxy->method('getUserExecutions')->willReturn([]);
-        $launchData = new LtiLaunchData([LtiLaunchData::USER_ID => $userId], []);
-        $deliveryExecution = $this->subject->findLastExecutionByUserAndDelivery($launchData, $deliveryId);
+        $deliveryExecution = $this->subject->findLastExecutionByUserAndDelivery($userId, $deliveryId);
 
         self::assertNull($deliveryExecution);
     }
@@ -136,8 +135,7 @@ class DeliveryExecutionFinderServiceTest extends TestCase
         $implementation = $this->createMock(DeliveryExecutionInterface::class);
 
         $this->executionServiceProxy->method('getUserExecutions')->willReturn([new DeliveryExecution($implementation)]);
-        $launchData = new LtiLaunchData([LtiLaunchData::USER_ID => $userId], []);
-        $deliveryExecution = $this->subject->findLastExecutionByUserAndDelivery($launchData, $deliveryId);
+        $deliveryExecution = $this->subject->findLastExecutionByUserAndDelivery($userId, $deliveryId);
 
         self::assertNotNull($deliveryExecution);
         $this->assertInstanceOf(DeliveryExecution::class, $deliveryExecution);

--- a/test/unit/model/DeliveryExecutionFinderServiceTest.php
+++ b/test/unit/model/DeliveryExecutionFinderServiceTest.php
@@ -123,7 +123,7 @@ class DeliveryExecutionFinderServiceTest extends TestCase
 
         $this->executionServiceProxy->method('getUserExecutions')->willReturn([]);
         $launchData = new LtiLaunchData([LtiLaunchData::USER_ID => $userId], []);
-        $deliveryExecution = $this->subject->findByUserAndDelivery($launchData, $deliveryId);
+        $deliveryExecution = $this->subject->findLastExecutionByUserAndDelivery($launchData, $deliveryId);
 
         self::assertNull($deliveryExecution);
     }
@@ -137,7 +137,7 @@ class DeliveryExecutionFinderServiceTest extends TestCase
 
         $this->executionServiceProxy->method('getUserExecutions')->willReturn([new DeliveryExecution($implementation)]);
         $launchData = new LtiLaunchData([LtiLaunchData::USER_ID => $userId], []);
-        $deliveryExecution = $this->subject->findByUserAndDelivery($launchData, $deliveryId);
+        $deliveryExecution = $this->subject->findLastExecutionByUserAndDelivery($launchData, $deliveryId);
 
         self::assertNotNull($deliveryExecution);
         $this->assertInstanceOf(DeliveryExecution::class, $deliveryExecution);

--- a/test/unit/model/DeliveryExecutionFinderServiceTest.php
+++ b/test/unit/model/DeliveryExecutionFinderServiceTest.php
@@ -23,12 +23,12 @@ use core_kernel_classes_Resource;
 use oat\generis\test\TestCase;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
 use oat\ltiDeliveryProvider\model\LtiResultAliasStorage;
+use oat\ltiTestReview\models\DeliveryExecutionFinderService;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoLti\models\classes\LtiInvalidLaunchDataException;
 use oat\taoLti\models\classes\LtiLaunchData;
-use oat\ltiTestReview\models\DeliveryExecutionFinderService;
 use oat\taoLti\models\classes\LtiVariableMissingException;
 
 class DeliveryExecutionFinderServiceTest extends TestCase
@@ -114,6 +114,33 @@ class DeliveryExecutionFinderServiceTest extends TestCase
         $deliveryExecution = $this->subject->findDeliveryExecution($launchData);
 
         $this->assertEquals($executionId, $deliveryExecution->getIdentifier());
+    }
+
+    public function testNotFoundDeliveryExecutionByUserAndDelivery(): void
+    {
+        $userId = 'test_user_id';
+        $deliveryId = 'http://backoffice.docker.localhost/ontologies/tao.rdf#i617822471ea2d126631ac77e4b86e48';
+
+        $this->executionServiceProxy->method('getUserExecutions')->willReturn([]);
+        $launchData = new LtiLaunchData([LtiLaunchData::USER_ID => $userId], []);
+        $deliveryExecution = $this->subject->findByUserAndDelivery($launchData, $deliveryId);
+
+        self::assertNull($deliveryExecution);
+    }
+
+    public function testFindDeliveryExecutionByUserAndDelivery(): void
+    {
+        $userId = 'test_user_id';
+        $deliveryId = 'http://backoffice.docker.localhost/ontologies/tao.rdf#i617822471ea2d126631ac77e4b86e48';
+
+        $implementation = $this->createMock(DeliveryExecutionInterface::class);
+
+        $this->executionServiceProxy->method('getUserExecutions')->willReturn([new DeliveryExecution($implementation)]);
+        $launchData = new LtiLaunchData([LtiLaunchData::USER_ID => $userId], []);
+        $deliveryExecution = $this->subject->findByUserAndDelivery($launchData, $deliveryId);
+
+        self::assertNotNull($deliveryExecution);
+        $this->assertInstanceOf(DeliveryExecution::class, $deliveryExecution);
     }
 
     public function testNotFoundDeliveryExecution()


### PR DESCRIPTION
# [TR-1919](https://oat-sa.atlassian.net/browse/TR-1919)

# Summary
Context about running review mode by `userId` and `deliveryId` without usage of `executionId` in claim set

# How to test
* install current branch version of package in `tao` on `nextgen-stack`
* start delivery with specified userId on a `tao` used as a tool with resource_link claim. For example 
```
    "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
        "id": "local_devkit_1"
    }
```
* run review mode for specified userId with deliveryId with next set of claims 
```
{
    "https://purl.imsglobal.org/spec/lti/claim/roles": [
        "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"
    ],
    "https://purl.imsglobal.org/spec/lti/claim/custom": {
        "custom_show_score": "true",
        "custom_show_correct": "true"
    },
   "https://purl.imsglobal.org/spec/lti/claim/for_user": {
       "user_id": "<string>",
    },
    "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
        "id": "local_devkit_1"
    }
}
```
review mode launch url example 
```
http://backoffice.docker.localhost/ltiTestReview/ReviewTool/launch1p3?delivery={deliveryId}
```
