### PR TITLE
Recorded audio is not available on review mode

### DIFF
--- a/models/QtiRunnerInitDataBuilder.php
+++ b/models/QtiRunnerInitDataBuilder.php
@@ -242,7 +242,7 @@ class QtiRunnerInitDataBuilder
         );
         $displayedVariables = $this->resultService->filterStructuredVariables($variables, $filterTypes);
 
-        $responses = ResponseVariableFormatter::formatStructuredVariablesToItemState($variables);
+        $responses = ResponseVariableFormatter::formatStructuredVariablesToItemState($variables, [], true);
         $excludedVariables = array_flip(['numAttempts', 'duration']);
 
         foreach ($displayedVariables as $itemKey => &$item) {


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-2972

## Summary
Responses with embedded files are not being rendered properly on review mode.

## How to test
1. Launch a test that has at least one interaction that stores a file (for example, Audio recording or File Upload)
[audio_recording_1640100368.zip](https://github.com/oat-sa/extension-lti-test-review/files/7756949/audio_recording_1640100368.zip)
2. Complete the test
3. Launch the test again in Review Mode (https://oat-sa.atlassian.net/l/c/Y26yhkAs)
4. Navigate to the item with respective interaction
5. The file should load without issues:
Audio recording interaction:
![image](https://user-images.githubusercontent.com/1084316/146972286-d5277b72-ff76-4ea8-be74-53e47629987e.png)

File upload interaction:
![image](https://user-images.githubusercontent.com/1084316/146972514-27fa4a0a-ea29-415b-bd16-dcc98e9aa027.png)



## Dependencies
https://github.com/oat-sa/extension-tao-outcomeui/pull/408

## Sandbox environment
Terre: http://test-infosign-tr-2972.playground.kitchen.it.taocloud.org:48891
Devkit: https://devkit-pg-cf87772fc920e62.cicd.gcp-eu.taocloud.org