### PR TITLE
Specify request for review execution by `resource link id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ The user id should be provided in the `for_user` claim:
 }
 ```
 
+Requested for review delivery execution can be specified by `resource_link_id` claim 
+(will be launched the latest delivery execution specified by `user_id`, `delivery_id` and `resource_link_id`)
+
+```json
+{
+  "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
+    "id": "unique_Id"
+  }
+}
+```
+
 For backwards compatibility, the following endpoint allows to select an exact delivery execution, whose id must be provided in a custom claim:
 
 ```

--- a/controller/Review.php
+++ b/controller/Review.php
@@ -103,7 +103,11 @@ class Review extends tao_actions_SinglePageModule
         if ($this->isSubmissionReviewRequestMessageProvided()) {
             $deliveryId = $this->getDeliveryId();
             $userId = $this->getUserId();
-            $execution = $finder->findLastExecutionByUserAndDelivery($userId, $deliveryId);
+            $resourceLinkId = null;
+            if ($launchData->hasVariable(LtiLaunchData::RESOURCE_LINK_ID)) {
+                $resourceLinkId = $this->ltiSession->getLtiLinkResource();
+            }
+            $execution = $finder->findLastExecutionByUserAndDelivery($userId, $deliveryId, $resourceLinkId);
 
             if ($execution === null) {
                 throw new LtiClientException(

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -21,7 +21,7 @@ namespace oat\ltiTestReview\models;
 
 use common_exception_Error;
 use common_exception_NotFound;
-use core_kernel_classes_Resource;
+use core_kernel_classes_Resource as Resource;
 use oat\ltiDeliveryProvider\model\execution\LtiDeliveryExecutionService;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
 use oat\ltiDeliveryProvider\model\LtiResultAliasStorage;
@@ -31,7 +31,6 @@ use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use oat\taoDelivery\model\execution\ServiceProxy as ExecutionServiceProxy;
 use oat\taoLti\models\classes\LtiInvalidLaunchDataException;
 use oat\taoLti\models\classes\LtiLaunchData;
-use oat\taoLti\models\classes\LtiService;
 use oat\taoLti\models\classes\LtiVariableMissingException;
 use tao_helpers_Date;
 
@@ -61,7 +60,7 @@ class DeliveryExecutionFinderService extends ConfigurableService
         $launchDataService = $this->getLaunchDataService();
         $ltiResultIdStorage = $this->getLtiResultIdStorage();
 
-        /** @var core_kernel_classes_Resource $execution */
+        /** @var Resource $execution */
         $execution = $launchDataService->findDeliveryExecutionFromLaunchData($launchData);
 
         if ($execution && $execution->exists()) {
@@ -88,9 +87,9 @@ class DeliveryExecutionFinderService extends ConfigurableService
     public function findLastExecutionByUserAndDelivery(
         string $userId,
         string $deliveryId,
-        ?core_kernel_classes_Resource $resourceLinkId = null
+        ?Resource $resourceLinkId = null
     ): ?DeliveryExecution {
-        $deliveryResource = new core_kernel_classes_Resource($deliveryId);
+        $deliveryResource = new Resource($deliveryId);
         if ($resourceLinkId === null) {
             $userDeliveryExecutions = $this->getExecutionServiceProxy()->getUserExecutions($deliveryResource, $userId);
         } else {

--- a/test/unit/model/DeliveryExecutionFinderServiceTest.php
+++ b/test/unit/model/DeliveryExecutionFinderServiceTest.php
@@ -21,6 +21,7 @@ namespace oat\ltiTestReview\test\unit\model;
 
 use core_kernel_classes_Resource;
 use oat\generis\test\TestCase;
+use oat\ltiDeliveryProvider\model\execution\LtiDeliveryExecutionService;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
 use oat\ltiDeliveryProvider\model\LtiResultAliasStorage;
 use oat\ltiTestReview\models\DeliveryExecutionFinderService;
@@ -42,6 +43,9 @@ class DeliveryExecutionFinderServiceTest extends TestCase
     /** @var ServiceProxy */
     private $executionServiceProxy;
 
+    /** @var LtiDeliveryExecutionService */
+    private $ltiDeliveryExecutionServiceMock;
+
     /** @var DeliveryExecutionFinderService */
     private $subject;
 
@@ -52,12 +56,14 @@ class DeliveryExecutionFinderServiceTest extends TestCase
         $this->ltiResultAliasStorage = $this->createMock(LtiResultAliasStorage::class);
         $this->ltiLaunchDataService = $this->createMock(LtiLaunchDataService::class);
         $this->executionServiceProxy = $this->createMock(ServiceProxy::class);
+        $this->ltiDeliveryExecutionServiceMock = $this->createMock(LtiDeliveryExecutionService::class);
 
         $this->subject = new DeliveryExecutionFinderService();
         $this->subject->setServiceLocator($this->getServiceLocatorMock([
             LtiResultAliasStorage::SERVICE_ID => $this->ltiResultAliasStorage,
             LtiLaunchDataService::SERVICE_ID => $this->ltiLaunchDataService,
-            ServiceProxy::SERVICE_ID => $this->executionServiceProxy
+            ServiceProxy::SERVICE_ID => $this->executionServiceProxy,
+            LtiDeliveryExecutionService::SERVICE_ID => $this->ltiDeliveryExecutionServiceMock
         ]));
     }
 
@@ -116,26 +122,52 @@ class DeliveryExecutionFinderServiceTest extends TestCase
         $this->assertEquals($executionId, $deliveryExecution->getIdentifier());
     }
 
-    public function testNotFoundDeliveryExecutionByUserAndDelivery(): void
+    public function testNotFoundDeliveryExecutionByUserAndDeliveryWithoutResourceLinkId(): void
     {
         $userId = 'test_user_id';
         $deliveryId = 'http://backoffice.docker.localhost/ontologies/tao.rdf#i617822471ea2d126631ac77e4b86e48';
+        $this->ltiDeliveryExecutionServiceMock->expects(self::never())->method('getLinkedDeliveryExecutions');
 
-        $this->executionServiceProxy->method('getUserExecutions')->willReturn([]);
+        $this->executionServiceProxy->expects(self::once())->method('getUserExecutions')->willReturn([]);
         $deliveryExecution = $this->subject->findLastExecutionByUserAndDelivery($userId, $deliveryId);
 
         self::assertNull($deliveryExecution);
     }
 
-    public function testFindDeliveryExecutionByUserAndDelivery(): void
+    public function testNotFoundDeliveryExecutionByUserAndDeliveryWithResourceLinkId(): void
     {
         $userId = 'test_user_id';
         $deliveryId = 'http://backoffice.docker.localhost/ontologies/tao.rdf#i617822471ea2d126631ac77e4b86e48';
+        $resourceLinkId = $this->createMock(core_kernel_classes_Resource::class);
+
+        $this->ltiDeliveryExecutionServiceMock
+            ->expects(self::once())
+            ->method('getLinkedDeliveryExecutions')
+            ->willReturn([]);
+
+        $this->executionServiceProxy->expects(self::never())->method('getUserExecutions')->willReturn([]);
+        $deliveryExecution = $this->subject->findLastExecutionByUserAndDelivery($userId, $deliveryId, $resourceLinkId);
+
+        self::assertNull($deliveryExecution);
+    }
+
+    public function testFindDeliveryExecutionByUserAndDeliveryWithResourceLinkId(): void
+    {
+        $userId = 'test_user_id';
+        $deliveryId = 'http://backoffice.docker.localhost/ontologies/tao.rdf#i617822471ea2d126631ac77e4b86e48';
+        $resourceLinkId = $this->createMock(core_kernel_classes_Resource::class);
 
         $implementation = $this->createMock(DeliveryExecutionInterface::class);
+        $this->ltiDeliveryExecutionServiceMock
+            ->expects(self::once())
+            ->method('getLinkedDeliveryExecutions')
+            ->willReturn([new DeliveryExecution($implementation)]);
 
-        $this->executionServiceProxy->method('getUserExecutions')->willReturn([new DeliveryExecution($implementation)]);
-        $deliveryExecution = $this->subject->findLastExecutionByUserAndDelivery($userId, $deliveryId);
+        $this->executionServiceProxy
+            ->expects(self::never())
+            ->method('getUserExecutions');
+
+        $deliveryExecution = $this->subject->findLastExecutionByUserAndDelivery($userId, $deliveryId, $resourceLinkId);
 
         self::assertNotNull($deliveryExecution);
         $this->assertInstanceOf(DeliveryExecution::class, $deliveryExecution);


### PR DESCRIPTION
# [TR-4373](https://oat-sa.atlassian.net/browse/TR-4373)

## Summary
Add support `https://purl.imsglobal.org/spec/lti/claim/resource_link` in submission review request to specify request delivery execution.

## How to test
- install branch
- launch delivery execution by lti 1.3 with resource_link claim
```
...
    "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
        "id": "unique_Id"
    }
...
```
- launch review with [SubmissionReviewRequestMessage](https://github.com/oat-sa/extension-lti-test-review/blob/master/README.md#lti-calls) with the same claim 
```
...
    "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
        "id": "unique_Id"
    }
...
```
[review request example](http://devkit.docker.localhost/platform/message/launch/submission-review?registration=backofficeToolRegistration&user_list=c3po&ags_scopes%5B0%5D=https://purl.imsglobal.org/spec/lti-ags/scope/score&ags_line_item_url=https://devkit-oat-demo.dev.gcp-eu.taocloud.org/platform/service/ags/context_id/lineitems/item_id&for_user_type=other&for_user_id=user_id&submission_review_url=http://backoffice.docker.localhost/ltiTestReview/ReviewTool/launch1p3?delivery%3Dencodede_delivery_id&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D,%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/custom%22:%20%7B%0D%0A%20%20%20%20%20%20%20%20%22custom_show_score%22:%20%22true%22,%0D%0A%20%20%20%20%20%20%20%20%22custom_show_correct%22:%20%22true%22%0D%0A%20%20%20%20%7D,%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/resource_link%22:%20%7B%0D%0A%20%20%20%20%20%20%20%20%22id%22:%20%22unique_id%22%0D%0A%20%20%20%20%7D%0D%0A%7D)
