### PR TITLE
feat: use mapEntries for correct response

### DIFF
--- a/views/js/review/plugins/content/item-answer/plugin.js
+++ b/views/js/review/plugins/content/item-answer/plugin.js
@@ -73,6 +73,10 @@ define([
                 response[identifier] = {
                     response: itemHelper.toResponse(_.keys(declaration.mapEntries), baseType, cardinality)
                 };
+            } else {
+                response[identifier] = {
+                    response: itemHelper.toResponse('', baseType, cardinality)
+                };
             }
 
         });

--- a/views/js/review/plugins/content/item-answer/plugin.js
+++ b/views/js/review/plugins/content/item-answer/plugin.js
@@ -38,7 +38,7 @@ define([
     /**
      * Gets the response of the current item
      * @param {runner} testRunner
-     * @return {Object}
+     * @returns {Object}
      */
     const getItemResponse = testRunner => {
         const context = testRunner.getTestContext();
@@ -57,7 +57,7 @@ define([
     /**
      * Gets the correct response of the current item
      * @param {runner} testRunner
-     * @return {Object}
+     * @returns {Object}
      */
     const getItemCorrectResponse = testRunner => {
         const declarations = itemHelper.getDeclarations(testRunner);
@@ -65,9 +65,16 @@ define([
         _.forEach(declarations, declaration => {
             const { attributes } = declaration;
             const { identifier, baseType, cardinality } = attributes || {};
-            response[identifier] = {
-                response: itemHelper.toResponse(declaration.correctResponse, baseType, cardinality)
-            };
+            if (!_.isEmpty(declaration.correctResponse)) {
+                response[identifier] = {
+                    response: itemHelper.toResponse(declaration.correctResponse, baseType, cardinality)
+                };
+            } else if (declaration.mapEntries && _.size(declaration.mapEntries)){
+                response[identifier] = {
+                    response: itemHelper.toResponse(_.keys(declaration.mapEntries), baseType, cardinality)
+                };
+            }
+
         });
         return response;
     };
@@ -113,6 +120,7 @@ define([
 
         /**
          * Called during the runner's render phase
+         * @returns {Promise}
          */
         render() {
             return promiseTimeout(new Promise(resolve => {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4504

Depends on: https://github.com/oat-sa/tao-item-runner-qti-fe/pull/317

## How to test:

- Create item with Math PCI, set answer in Response
- Create Delivery, run it by lti tool
- Set right answer in Math PCI
- Run review by lti tool
- Check that Math PCI is has right answer
![image](https://user-images.githubusercontent.com/25976342/191282959-572dd5ed-b178-46a5-bb39-348ed03e74d2.png)

- Create item with Math PCI, don not set answer in Response
- Create Delivery, run it by lti tool
- Set right answer in Math PCI
- Run review by lti tool
- Check that Math PCI is has wrong answer
![image](https://user-images.githubusercontent.com/25976342/191283384-76767f68-ff56-43e4-94f4-ea01e780fc48.png)
