### PR TITLE
fix: Clear the pause reason for the test being restarted

### DIFF
--- a/controller/Review.php
+++ b/controller/Review.php
@@ -121,6 +121,7 @@ class Review extends tao_actions_SinglePageModule
         }
 
         $this->getConcurringSessionService()->pauseConcurrentSessions($execution);
+        $this->getConcurringSessionService()->clearConcurringSession($execution);
 
         $delivery = $execution->getDelivery();
 


### PR DESCRIPTION
**Associated Jira issue:** [INF-262](https://oat-sa.atlassian.net/browse/INF-262)

Make sure the pause reason associated to a delivery execution is cleared as soon as the execution is (re)started. Otherwise, once the test taker completes the test, the pause reason is still there, which makes the test runner to show a page stating that the test was "paused due to a concurrent session" instead of finished normally.

[INF-262]: https://oat-sa.atlassian.net/browse/INF-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ