### PR TITLE
Fix/inf 263/item answer showcorrect but no showscore

### DIFF
--- a/views/js/review/plugins/content/item-answer/item-answer.js
+++ b/views/js/review/plugins/content/item-answer/item-answer.js
@@ -219,11 +219,11 @@ define([
             /**
              * Defines the item status
              * @param {String} statusType
-             * @param {Boolean} hasCorrectResponseDefined
+             * @param {Boolean} hasCorrectResponseTab
              * @returns {itemAnswerComponent}
              * @fires statuschange
              */
-            setStatus(statusType, hasCorrectResponseDefined) {
+            setStatus(statusType, hasCorrectResponseTab) {
                 let status;
                 if (statusType === 'info') {
                     status = 'informational';
@@ -244,10 +244,9 @@ define([
                 }
 
                 const statusChanged = this.getConfig().status !== status;
-                const hasCorrectResponseChanged =
-                    this.getConfig().hasCorrectResponseDefined !== hasCorrectResponseDefined;
+                const hasCorrectResponseChanged = this.getConfig().hasCorrectResponseTab !== hasCorrectResponseTab;
                 this.getConfig().status = status;
-                this.getConfig().hasCorrectResponseDefined = hasCorrectResponseDefined;
+                this.getConfig().hasCorrectResponseTab = hasCorrectResponseTab;
 
                 // reflect the state onto the component
                 states.forEach(state => this.setState(state, status === state));
@@ -255,16 +254,20 @@ define([
                 /**
                  * @event statuschange
                  * @param {Boolean} statusChanged - If status actually changed or not
-                 * @param {Boolean} hasCorrectResponseChanged - If hasCorrectResponseDefined actually changed or not
+                 * @param {Boolean} hasCorrectResponseChanged - If hasCorrectResponseTab actually changed or not
                  */
                 this.trigger('statuschange', statusChanged, hasCorrectResponseChanged);
                 return this;
             },
 
+            /**
+             * Calculates which tabs should be shown based on component state and config
+             * @returns {Array<Object>}
+             */
             calculateTabs() {
-                const { showCorrect, hasCorrectResponseDefined, status } = this.getConfig();
+                const { showCorrect, hasCorrectResponseTab, status } = this.getConfig();
                 const tabs = [getAnswerTab(status)];
-                if (showCorrect && hasCorrectResponseDefined) {
+                if (showCorrect && hasCorrectResponseTab) {
                     tabs.push(correctTab);
                 }
                 return tabs;

--- a/views/js/review/plugins/content/item-answer/item-answer.js
+++ b/views/js/review/plugins/content/item-answer/item-answer.js
@@ -111,17 +111,13 @@ define([
     };
 
     /**
-     * List of possible states
+     * List of possible statuses/states
      * @type {String[]}
      */
-    const states = ['correct', 'incorrect', 'skipped', 'informational', 'partial', 'pending', 'default'];
+    const statuses = ['correct', 'incorrect', 'skipped', 'informational', 'partial', 'pending', 'default', 'no-score'];
 
     /**
      * Builds a component that shows up the item status regarding the responses.
-     * States:
-     * - correct - Whether or not the item got correct responses
-     * - skipped - Whether or not the item has been skipped. This option only matters if `correct` is set.
-     * - informational - Whether or not the item is informational. If so, the component won't display anything.
      *
      * @example
      *  const container = $();
@@ -218,29 +214,14 @@ define([
 
             /**
              * Defines the item status
-             * @param {String} statusType
+             * @param {String} status
              * @param {Boolean} hasCorrectResponseTab
              * @returns {itemAnswerComponent}
              * @fires statuschange
              */
-            setStatus(statusType, hasCorrectResponseTab) {
-                let status;
-                if (statusType === 'info') {
-                    status = 'informational';
-                } else if (statusType === 'score-pending') {
-                    status = 'pending';
-                } else if (statusType === 'correct') {
-                    status = 'correct';
-                } else if (statusType === 'incorrect') {
-                    status = 'incorrect';
-                } else if (statusType === 'score-partial') {
-                    status = 'partial';
-                } else if (statusType === 'default') {
-                    status = 'default';
-                } else if (statusType === 'skipped') {
-                    status = 'skipped';
-                } else {
-                    status = 'no-score';
+            setStatus(status, hasCorrectResponseTab) {
+                if (!statuses.includes(status)) {
+                    throw new TypeError('Unknown status for review item-answer');
                 }
 
                 const statusChanged = this.getConfig().status !== status;
@@ -249,7 +230,7 @@ define([
                 this.getConfig().hasCorrectResponseTab = hasCorrectResponseTab;
 
                 // reflect the state onto the component
-                states.forEach(state => this.setState(state, status === state));
+                statuses.forEach(availableStatus => this.setState(availableStatus, status === availableStatus));
 
                 /**
                  * @event statuschange

--- a/views/js/review/plugins/content/item-answer/plugin.js
+++ b/views/js/review/plugins/content/item-answer/plugin.js
@@ -133,7 +133,13 @@ define([
         }
     };
 
-    const getHasCorrectResponseDefined = item => {
+    /**
+     * Checks if item should have correct response tab
+     *  (`showCorrect` config option should be checked outside)
+     * @param {Object} item
+     * @returns {Boolean}
+     */
+    const getHasCorrectResponseTab = item => {
         const statusWithScore = getItemStatusType(item, true);
         return ['score-pending', 'incorrect', 'score-partial'].includes(statusWithScore);
     };
@@ -178,8 +184,8 @@ define([
                             const item = mapHelper.getItem(testRunner.getTestMap(), itemRef);
 
                             const statusType = getItemStatusType(item, showScore);
-                            const hasCorrectResponseDefined = getHasCorrectResponseDefined(item);
-                            itemAnswer.setStatus(statusType, hasCorrectResponseDefined);
+                            const hasCorrectResponseTab = getHasCorrectResponseTab(item);
+                            itemAnswer.setStatus(statusType, hasCorrectResponseTab);
 
                             itemAnswer.setHasNoAnswer(item.skipped);
 

--- a/views/js/review/plugins/content/item-answer/plugin.js
+++ b/views/js/review/plugins/content/item-answer/plugin.js
@@ -99,7 +99,7 @@ define([
     };
 
     /**
-     * Should match to `review-panel` plugin's item types
+     * Should match `review-panel` plugin's item types
      * @param {Object} item
      * @param {Boolean} withScore
      * @returns {String}
@@ -107,10 +107,10 @@ define([
     const getItemStatusType = (item, withScore) => {
         if (withScore) {
             if (item.informational) {
-                return 'info';
+                return 'informational';
             }
             if (item.isExternallyScored && item.pendingExternalScore) {
-                return 'score-pending';
+                return 'pending';
             }
             if (item.maxScore && item.score > 0 && item.score === item.maxScore) {
                 return 'correct';
@@ -119,12 +119,12 @@ define([
                 return 'incorrect';
             }
             if (item.maxScore && item.score > 0 && item.score < item.maxScore) {
-                return 'score-partial';
+                return 'partial';
             }
             return 'no-score';
         } else {
             if (item.informational) {
-                return 'info';
+                return 'informational';
             }
             if (item.skipped) {
                 return 'skipped';
@@ -141,7 +141,7 @@ define([
      */
     const getHasCorrectResponseTab = item => {
         const statusWithScore = getItemStatusType(item, true);
-        return ['score-pending', 'correct', 'incorrect', 'score-partial'].includes(statusWithScore);
+        return ['pending', 'correct', 'incorrect', 'partial'].includes(statusWithScore);
     };
 
     /**
@@ -191,7 +191,7 @@ define([
 
                             let score = '';
                             if (
-                                ['correct', 'incorrect', 'score-partial', 'score-pending'].includes(statusType) &&
+                                ['correct', 'incorrect', 'partial', 'pending'].includes(statusType) &&
                                 item.maxScore
                             ) {
                                 score = `${item.score || 0}/${item.maxScore}`;

--- a/views/js/review/plugins/content/item-answer/plugin.js
+++ b/views/js/review/plugins/content/item-answer/plugin.js
@@ -141,7 +141,7 @@ define([
      */
     const getHasCorrectResponseTab = item => {
         const statusWithScore = getItemStatusType(item, true);
-        return ['score-pending', 'incorrect', 'score-partial'].includes(statusWithScore);
+        return ['score-pending', 'correct', 'incorrect', 'score-partial'].includes(statusWithScore);
     };
 
     /**

--- a/views/js/review/plugins/content/item-answer/plugin.js
+++ b/views/js/review/plugins/content/item-answer/plugin.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2024 Open Assessment Technologies SA ;
  */
 /**
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
@@ -133,6 +133,11 @@ define([
         }
     };
 
+    const getHasCorrectResponseDefined = item => {
+        const statusWithScore = getItemStatusType(item, true);
+        return ['score-pending', 'incorrect', 'score-partial'].includes(statusWithScore);
+    };
+
     /**
      * Test Review Plugin : Item Answer Tabs
      * Displays a tabs bar that allows to switch between responses and correct responses
@@ -173,23 +178,8 @@ define([
                             const item = mapHelper.getItem(testRunner.getTestMap(), itemRef);
 
                             const statusType = getItemStatusType(item, showScore);
-                            if (statusType === 'info') {
-                                itemAnswer.setInformational();
-                            } else if (statusType === 'score-pending') {
-                                itemAnswer.setPending();
-                            } else if (statusType === 'correct') {
-                                itemAnswer.setCorrect();
-                            } else if (statusType === 'incorrect') {
-                                itemAnswer.setIncorrect();
-                            } else if (statusType === 'score-partial') {
-                                itemAnswer.setPartial();
-                            } else if (statusType === 'default') {
-                                itemAnswer.setDefault();
-                            } else if (statusType === 'skipped') {
-                                itemAnswer.setSkipped();
-                            } else {
-                                itemAnswer.setNoScore();
-                            }
+                            const hasCorrectResponseDefined = getHasCorrectResponseDefined(item);
+                            itemAnswer.setStatus(statusType, hasCorrectResponseDefined);
 
                             itemAnswer.setHasNoAnswer(item.skipped);
 

--- a/views/js/test/review/plugins/content/item-answer/item-answer/test.js
+++ b/views/js/test/review/plugins/content/item-answer/item-answer/test.js
@@ -740,7 +740,7 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setStatus('info', false), instance, 'setStatus(info) is fluent');
+                        assert.strictEqual(instance.setStatus('informational', false), instance, 'setStatus(info) is fluent');
 
                         return promise;
                     })
@@ -1258,7 +1258,7 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setStatus('info', false), instance, 'setStatus(info) is fluent');
+                        assert.strictEqual(instance.setStatus('informational', false), instance, 'setStatus(info) is fluent');
 
                         return promise;
                     })
@@ -1331,9 +1331,9 @@ define([
                     instance.setStatus('skipped', currentHasCorrectResponse);
                     break;
 
-                case 'info':
+                case 'informational':
                     instance.setScore('');
-                    instance.setStatus('info', currentHasCorrectResponse);
+                    instance.setStatus('informational', currentHasCorrectResponse);
                     break;
             }
         };

--- a/views/js/test/review/plugins/content/item-answer/item-answer/test.js
+++ b/views/js/test/review/plugins/content/item-answer/item-answer/test.js
@@ -87,13 +87,6 @@ define([
         {title: 'getStatus'},
         {title: 'setStatus'},
         {title: 'getActiveTab'},
-        {title: 'isCorrect'},
-        {title: 'isSkipped'},
-        {title: 'isInformational'},
-        {title: 'setCorrect'},
-        {title: 'setIncorrect'},
-        {title: 'setSkipped'},
-        {title: 'setInformational'}
     ]).test('component API ', (data, assert) => {
         const instance = getInstance('#fixture-api');
         assert.expect(1);
@@ -175,7 +168,7 @@ define([
         const ready = assert.async();
         const $container = $('#fixture-init');
 
-        assert.expect(7);
+        assert.expect(4);
 
         const instance = itemAnswerFactory($container, data.config)
             .on('init', function () {
@@ -186,9 +179,6 @@ define([
 
                 assert.strictEqual(instance.getScore(), data.expected.score, 'The expected score is set');
                 assert.strictEqual(instance.getStatus(), data.expected.status, 'The expected status is set');
-                assert.strictEqual(instance.isCorrect(), data.expected.correct, 'The correct status is set as expected');
-                assert.strictEqual(instance.isSkipped(), data.expected.skipped, 'The skipped status is set as expected');
-                assert.strictEqual(instance.isInformational(), data.expected.informational, 'The informational status is set as expected');
 
                 instance.destroy();
             })
@@ -357,8 +347,8 @@ define([
 
                         const promise = Promise.all([
                             new Promise(resolve => {
-                                instance.on('statuschange.test', status => {
-                                    assert.strictEqual(status, 'incorrect', 'The status changed to incorrect');
+                                instance.on('statuschange.test', () => {
+                                    assert.strictEqual(instance.getConfig().status, 'incorrect', 'The status changed to incorrect');
                                     resolve();
                                 });
                             }),
@@ -370,7 +360,7 @@ define([
                             })
                         ]);
 
-                        instance.setIncorrect();
+                        instance.setStatus('incorrect', true);
 
                         return promise;
                     })
@@ -558,7 +548,7 @@ define([
         const ready = assert.async();
         const $container = $('#fixture-status');
 
-        assert.expect(77);
+        assert.expect(69);
 
         assert.strictEqual($container.children().length, 0, 'The container is empty');
 
@@ -598,8 +588,8 @@ define([
 
                         const promise = Promise.all([
                             new Promise(resolve => {
-                                instance.on('statuschange.test', (status, change) => {
-                                    assert.strictEqual(status, 'skipped', 'The status changed to skipped');
+                                instance.on('statuschange.test', (change) => {
+                                    assert.strictEqual(instance.getConfig().status, 'skipped', 'The status changed to skipped');
                                     assert.strictEqual(change, true, 'The status has actually changed');
                                     resolve();
                                 });
@@ -612,15 +602,12 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setStatus('skipped'), instance, 'setStatus() is fluent');
+                        assert.strictEqual(instance.setStatus('skipped', false), instance, 'setStatus() is fluent');
 
                         return promise;
                     })
                     .then(() => {
-                        assert.strictEqual(instance.isCorrect(), false, 'The item is not correct');
-                        assert.strictEqual(instance.isSkipped(), true, 'The item is skipped');
-                        assert.strictEqual(instance.isInformational(), false, 'The item is not informational');
-
+                        assert.strictEqual(instance.getStatus(), 'skipped', 'The item is skipped');
                         assert.strictEqual($container.children().is('.correct'), false, 'The component did not get the state correct');
                         assert.strictEqual($container.children().is('.incorrect'), false, 'The component did not get the state incorrect');
                         assert.strictEqual($container.children().is('.skipped'), true, 'The component got the state skipped');
@@ -642,8 +629,8 @@ define([
 
                         const promise = Promise.all([
                             new Promise(resolve => {
-                                instance.on('statuschange.test', (status, change) => {
-                                    assert.strictEqual(status, 'correct', 'The status changed to correct');
+                                instance.on('statuschange.test', (change) => {
+                                    assert.strictEqual(instance.getConfig().status, 'correct', 'The status changed to correct');
                                     assert.strictEqual(change, true, 'The status has actually changed');
                                     resolve();
                                 });
@@ -656,15 +643,12 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setStatus('correct'), instance, 'setStatus() is fluent');
+                        assert.strictEqual(instance.setStatus('correct', false), instance, 'setStatus() is fluent');
 
                         return promise;
                     })
                     .then(() => {
-                        assert.strictEqual(instance.isCorrect(), true, 'The item is correct');
-                        assert.strictEqual(instance.isSkipped(), false, 'The item is not skipped');
-                        assert.strictEqual(instance.isInformational(), false, 'The item is not informational');
-
+                        assert.strictEqual(instance.getStatus(), 'correct', 'The item is correct');
                         assert.strictEqual($container.children().is('.correct'), true, 'The component got the state correct');
                         assert.strictEqual($container.children().is('.incorrect'), false, 'The component did not get the state incorrect');
                         assert.strictEqual($container.children().is('.skipped'), false, 'The component did not get the state skipped');
@@ -682,8 +666,8 @@ define([
 
                         const promise = Promise.all([
                             new Promise(resolve => {
-                                instance.on('statuschange.test', (status, change) => {
-                                    assert.strictEqual(status, 'incorrect', 'The status changed to incorrect');
+                                instance.on('statuschange.test', (change) => {
+                                    assert.strictEqual(instance.getConfig().status, 'incorrect', 'The status changed to incorrect');
                                     assert.strictEqual(change, true, 'The status has actually changed');
                                     resolve();
                                 });
@@ -696,7 +680,7 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setStatus('incorrect'), instance, 'setStatus() is fluent');
+                        assert.strictEqual(instance.setStatus('incorrect', true), instance, 'setStatus() is fluent');
 
                         return promise;
                     })
@@ -705,8 +689,8 @@ define([
 
                         const promise = Promise.all([
                             new Promise(resolve => {
-                                instance.on('statuschange.test', (status, change) => {
-                                    assert.strictEqual(status, 'incorrect', 'The status changed to incorrect');
+                                instance.on('statuschange.test', (change) => {
+                                    assert.strictEqual(instance.getConfig().status, 'incorrect', 'The status changed to incorrect');
                                     assert.strictEqual(change, false, 'The status has not actually changed');
                                     resolve();
                                 });
@@ -719,15 +703,12 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setStatus('incorrect'), instance, 'setStatus() is fluent');
+                        assert.strictEqual(instance.setStatus('incorrect', true), instance, 'setStatus() is fluent');
 
                         return promise;
                     })
                     .then(() => {
-                        assert.strictEqual(instance.isCorrect(), false, 'The item is not correct');
-                        assert.strictEqual(instance.isSkipped(), false, 'The item is not skipped');
-                        assert.strictEqual(instance.isInformational(), false, 'The item is not informational');
-
+                        assert.strictEqual(instance.getStatus(), 'incorrect', 'The item is incorrect');
                         assert.strictEqual($container.children().is('.correct'), false, 'The component did not get the state correct');
                         assert.strictEqual($container.children().is('.incorrect'), true, 'The component got the state incorrect');
                         assert.strictEqual($container.children().is('.skipped'), false, 'The component did not get the state skipped');
@@ -745,8 +726,8 @@ define([
 
                         const promise = Promise.all([
                             new Promise(resolve => {
-                                instance.on('statuschange.test', (status, change) => {
-                                    assert.strictEqual(status, 'informational', 'The status changed to informational');
+                                instance.on('statuschange.test', (change) => {
+                                    assert.strictEqual(instance.getConfig().status, 'informational', 'The status changed to informational');
                                     assert.strictEqual(change, true, 'The status has actually changed');
                                     resolve();
                                 });
@@ -759,15 +740,12 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setStatus('informational'), instance, 'setStatus() is fluent');
+                        assert.strictEqual(instance.setStatus('info', false), instance, 'setStatus(info) is fluent');
 
                         return promise;
                     })
                     .then(() => {
-                        assert.strictEqual(instance.isCorrect(), false, 'The item is not correct');
-                        assert.strictEqual(instance.isSkipped(), false, 'The item is not skipped');
-                        assert.strictEqual(instance.isInformational(), true, 'The item is informational');
-
+                        assert.strictEqual(instance.getStatus(), 'informational', 'The item is informational');
                         assert.strictEqual($container.children().is('.correct'), false, 'The component did not get the state correct');
                         assert.strictEqual($container.children().is('.incorrect'), false, 'The component did not get the state incorrect');
                         assert.strictEqual($container.children().is('.skipped'), false, 'The component did not get the state skipped');
@@ -791,6 +769,7 @@ define([
                 ready();
             });
     });
+
 
     QUnit.cases.init([{
         title: 'default',
@@ -828,7 +807,7 @@ define([
         const ready = assert.async();
         const $container = $('#fixture-correct');
 
-        assert.expect(34);
+        assert.expect(32);
 
         assert.strictEqual($container.children().length, 0, 'The container is empty');
 
@@ -866,8 +845,8 @@ define([
 
                         const promise = Promise.all([
                             new Promise(resolve => {
-                                instance.on('statuschange.test', (status, change) => {
-                                    assert.strictEqual(status, 'correct', 'The status changed to correct');
+                                instance.on('statuschange.test', (change) => {
+                                    assert.strictEqual(instance.getConfig().status, 'correct', 'The status changed to correct');
                                     assert.strictEqual(change, true, 'The status has actually changed');
                                     resolve();
                                 });
@@ -880,15 +859,12 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setCorrect(), instance, 'setCorrect() is fluent');
+                        assert.strictEqual(instance.setStatus('correct', false), instance, 'setStatus(correct) is fluent');
 
                         return promise;
                     })
                     .then(() => {
-                        assert.strictEqual(instance.isCorrect(), true, 'The item is correct');
-                        assert.strictEqual(instance.isSkipped(), false, 'The item is not skipped');
-                        assert.strictEqual(instance.isInformational(), false, 'The item is not informational');
-
+                        assert.strictEqual(instance.getStatus(), 'correct', 'The item is correct');
                         assert.strictEqual($container.children().is('.correct'), true, 'The component got the state correct');
                         assert.strictEqual($container.children().is('.incorrect'), false, 'The component did not get the state incorrect');
                         assert.strictEqual($container.children().is('.skipped'), false, 'The component did not get the state skipped');
@@ -896,11 +872,7 @@ define([
                         assert.strictEqual($container.find('.item-answer-status').text().trim(), '', 'The status area is empty');
 
                         assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab[data-tab-name="answer"]').length, 1, 'The tab "answer" is set');
-                        if (data.expected.showCorrect) {
-                            assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 2, 'Two tabs should be present');
-                        } else {
-                            assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one tab should be present');
-                        }
+                        assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one tab should be present');
                         if (data.expected.showCorrect) {
                             assert.strictEqual($container.find('[data-tab-name="answer"] .icon').is(data.expected.icon), true, 'The expected icon is set');
                         } else {
@@ -970,7 +942,7 @@ define([
         const ready = assert.async();
         const $container = $('#fixture-incorrect');
 
-        assert.expect(35);
+        assert.expect(33);
 
         assert.strictEqual($container.children().length, 0, 'The container is empty');
 
@@ -1008,8 +980,8 @@ define([
 
                         const promise = Promise.all([
                             new Promise(resolve => {
-                                instance.on('statuschange.test', (status, change) => {
-                                    assert.strictEqual(status, 'incorrect', 'The status changed to incorrect');
+                                instance.on('statuschange.test', (change) => {
+                                    assert.strictEqual(instance.getConfig().status, 'incorrect', 'The status changed to incorrect');
                                     assert.strictEqual(change, true, 'The status has actually changed');
                                     resolve();
                                 });
@@ -1022,15 +994,12 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setIncorrect(), instance, 'setIncorrect() is fluent');
+                        assert.strictEqual(instance.setStatus('incorrect', true), instance, 'setStatus(incorrect) is fluent');
 
                         return promise;
                     })
                     .then(() => {
-                        assert.strictEqual(instance.isCorrect(), false, 'The item is not correct');
-                        assert.strictEqual(instance.isSkipped(), false, 'The item is not skipped');
-                        assert.strictEqual(instance.isInformational(), false, 'The item is not informational');
-
+                        assert.strictEqual(instance.getStatus(), 'incorrect', 'The item is incorrect');
                         assert.strictEqual($container.children().is('.correct'), false, 'The component did not get the state correct');
                         assert.strictEqual($container.children().is('.incorrect'), true, 'The component got the state incorrect');
                         assert.strictEqual($container.children().is('.skipped'), false, 'The component did not get the state skipped');
@@ -1110,7 +1079,7 @@ define([
         const $container = $('#fixture-skipped');
         const skippedText = '';
 
-        assert.expect(35);
+        assert.expect(33);
 
         assert.strictEqual($container.children().length, 0, 'The container is empty');
 
@@ -1148,8 +1117,8 @@ define([
 
                         const promise = Promise.all([
                             new Promise(resolve => {
-                                instance.on('statuschange.test', (status, change) => {
-                                    assert.strictEqual(status, 'skipped', 'The status changed to skipped');
+                                instance.on('statuschange.test', (change) => {
+                                    assert.strictEqual(instance.getConfig().status, 'skipped', 'The status changed to skipped');
                                     assert.strictEqual(change, true, 'The status has actually changed');
                                     resolve();
                                 });
@@ -1162,15 +1131,12 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setSkipped(), instance, 'setSkipped() is fluent');
+                        assert.strictEqual(instance.setStatus('skipped', false), instance, 'setStatus(skipped) is fluent');
 
                         return promise;
                     })
                     .then(() => {
-                        assert.strictEqual(instance.isCorrect(), false, 'The item is not correct');
-                        assert.strictEqual(instance.isSkipped(), true, 'The item is skipped');
-                        assert.strictEqual(instance.isInformational(), false, 'The item is not informational');
-
+                        assert.strictEqual(instance.getStatus(), 'skipped', 'The item is skipped');
                         assert.strictEqual($container.children().is('.correct'), false, 'The component did not get the state correct');
                         assert.strictEqual($container.children().is('.incorrect'), false, 'The component did not get the state incorrect');
                         assert.strictEqual($container.children().is('.skipped'), true, 'The component got the state skipped');
@@ -1240,7 +1206,7 @@ define([
         const ready = assert.async();
         const $container = $('#fixture-informational');
 
-        assert.expect(34);
+        assert.expect(32);
 
         assert.strictEqual($container.children().length, 0, 'The container is empty');
 
@@ -1278,8 +1244,8 @@ define([
 
                         const promise = Promise.all([
                             new Promise(resolve => {
-                                instance.on('statuschange.test', (status, change) => {
-                                    assert.strictEqual(status, 'informational', 'The status changed to informational');
+                                instance.on('statuschange.test', (change) => {
+                                    assert.strictEqual(instance.getConfig().status, 'informational', 'The status changed to informational');
                                     assert.strictEqual(change, false, 'The status has not actually changed');
                                     resolve();
                                 });
@@ -1292,15 +1258,12 @@ define([
                             })
                         ]);
 
-                        assert.strictEqual(instance.setInformational(), instance, 'setInformational() is fluent');
+                        assert.strictEqual(instance.setStatus('info', false), instance, 'setStatus(info) is fluent');
 
                         return promise;
                     })
                     .then(() => {
-                        assert.strictEqual(instance.isCorrect(), false, 'The item is not correct');
-                        assert.strictEqual(instance.isSkipped(), false, 'The item is not skipped');
-                        assert.strictEqual(instance.isInformational(), true, 'The item is informational');
-
+                        assert.strictEqual(instance.getStatus(), 'informational', 'The item is informational');
                         assert.strictEqual($container.children().is('.correct'), false, 'The component did not get the state correct');
                         assert.strictEqual($container.children().is('.incorrect'), false, 'The component did not get the state incorrect');
                         assert.strictEqual($container.children().is('.skipped'), false, 'The component did not get the state skipped');
@@ -1347,28 +1310,30 @@ define([
         let instance = null;
         let componentDisabled = false;
         let currentStatus = 'correct';
+        let currentHasCorrectResponse = false;
 
-        const setStatus = status => {
+        const setStatus = (status, hasCorrectResponse) => {
             currentStatus = status;
+            currentHasCorrectResponse = hasCorrectResponse;
             switch (status) {
                 case 'correct':
                     instance.setScore('5/5');
-                    instance.setCorrect();
+                    instance.setStatus('correct', currentHasCorrectResponse);
                     break;
 
                 case 'incorrect':
                     instance.setScore('3/5');
-                    instance.setIncorrect();
+                    instance.setStatus('incorrect', currentHasCorrectResponse);
                     break;
 
                 case 'skipped':
                     instance.setScore('0/5');
-                    instance.setSkipped();
+                    instance.setStatus('skipped', currentHasCorrectResponse);
                     break;
 
-                case 'informational':
+                case 'info':
                     instance.setScore('');
-                    instance.setInformational();
+                    instance.setStatus('info', currentHasCorrectResponse);
                     break;
             }
         };
@@ -1394,7 +1359,7 @@ define([
                             if (componentDisabled) {
                                 instance.disable();
                             }
-                            setStatus(currentStatus);
+                            setStatus(currentStatus, currentHasCorrectResponse);
                             resolve();
                         })
                         .on('statuschange tabchange', () => {

--- a/views/js/test/review/plugins/content/item-answer/plugin/test.js
+++ b/views/js/test/review/plugins/content/item-answer/plugin/test.js
@@ -284,7 +284,7 @@ define([
                     }))
                     .then(() => {
                         assert.strictEqual($container.find('.item-answer').is('.correct'), true, 'The component is set to "correct"');
-                        assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one tab should be present');
+                        assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 2, 'Two tabs should be present');
                         assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab[data-tab-name="answer"]').length, 1, 'The tab "answer" is set');
                         assert.strictEqual($container.find('.item-answer-score').text().trim(), `${__('Your Score:')} 1/1`, 'The score is set');
                         assert.strictEqual($container.find('.item-answer-status').text().trim(), '', 'The status is empty');
@@ -451,7 +451,11 @@ define([
                         } else {
                             assert.strictEqual($container.find('.item-answer').is('.default'), true, 'The component is set to "default"');
                         }
-                        assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one tab should be present');
+                        if (data.expected.showCorrect) {
+                            assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 2, 'Two tabs should be present');
+                        } else {
+                            assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one should be present');
+                        }
                         assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab[data-tab-name="answer"]').length, 1, 'The tab "answer" is set');
                         if (data.expected.showScore) {
                             assert.strictEqual($container.find('.item-answer-score').text().trim(), `${__('Your Score:')} 1/1`, 'The score is set');

--- a/views/js/test/review/plugins/content/item-answer/plugin/test.js
+++ b/views/js/test/review/plugins/content/item-answer/plugin/test.js
@@ -284,11 +284,7 @@ define([
                     }))
                     .then(() => {
                         assert.strictEqual($container.find('.item-answer').is('.correct'), true, 'The component is set to "correct"');
-                        if (config.showScore) {
-                            assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 2, 'Only two tab should be present');
-                        } else {
-                            assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one tab should be present');
-                        }
+                        assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one tab should be present');
                         assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab[data-tab-name="answer"]').length, 1, 'The tab "answer" is set');
                         assert.strictEqual($container.find('.item-answer-score').text().trim(), `${__('Your Score:')} 1/1`, 'The score is set');
                         assert.strictEqual($container.find('.item-answer-status').text().trim(), '', 'The status is empty');
@@ -307,11 +303,7 @@ define([
                             .next();
                     }))
                     .then(() => {
-                        if (config.showScore) {
-                            assert.strictEqual($container.find('.item-answer').is('.skipped'), false, 'The component is set to "skipped"');
-                        } else {
-                            assert.strictEqual($container.find('.item-answer').is('.skipped'), true, 'The component is set to "skipped"');
-                        }
+                        assert.strictEqual($container.find('.item-answer').is('.incorrect'), true, 'The component is set to "incorrect"');
                         assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 2, 'Two tabs should be present');
                         assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab[data-tab-name="answer"]').length, 1, 'The tab "answer" is set');
                         assert.strictEqual($container.find('.item-answer-score').text().trim(), `${__('Your Score:')} 0/1`, 'The score is set');
@@ -454,12 +446,12 @@ define([
                             });
                     }))
                     .then(() => {
-                        assert.strictEqual($container.find('.item-answer').is('.correct'), data.expected.showScore, 'The component is set to "correct"');
-                        if (data.expected.showScore && data.expected.showCorrect) {
-                            assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 2, 'Only two tab should be present');
+                        if (data.expected.showScore) {
+                            assert.strictEqual($container.find('.item-answer').is('.correct'), true, 'The component is set to "correct"');
                         } else {
-                            assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one tab should be present');
+                            assert.strictEqual($container.find('.item-answer').is('.default'), true, 'The component is set to "default"');
                         }
+                        assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one tab should be present');
                         assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab[data-tab-name="answer"]').length, 1, 'The tab "answer" is set');
                         if (data.expected.showScore) {
                             assert.strictEqual($container.find('.item-answer-score').text().trim(), `${__('Your Score:')} 1/1`, 'The score is set');
@@ -487,8 +479,12 @@ define([
                             .next();
                     }))
                     .then(() => {
-                        assert.strictEqual($container.find('.item-answer').is('.skipped'), !data.expected.showScore, 'The component is set to "skipped"');
-                        if (data.expected.showCorrect && data.expected.showScore) {
+                        if (data.expected.showScore) {
+                            assert.strictEqual($container.find('.item-answer').is('.incorrect'), true, 'The component is set to "incorrect"');
+                        } else {
+                            assert.strictEqual($container.find('.item-answer').is('.skipped'), true, 'The component is set to "skipped"');
+                        }
+                        if (data.expected.showCorrect) {
                             assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 2, 'Two tabs should be present');
                         } else {
                             assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one tab should be present');
@@ -506,7 +502,7 @@ define([
                         assert.strictEqual($item.find('.result-area [data-identifier="choice_2"]').length, 1, 'Choice #2 is selected');
                         assert.strictEqual($item.find('.result-area [data-identifier="choice_4"]').length, 1, 'Choice #4 is selected');
 
-                        if (data.expected.showScore && data.expected.showCorrect) {
+                        if (data.expected.showCorrect) {
                             assert.strictEqual($container.find('.item-answer .tab[data-tab-name="correct"]').length, 1, 'The tab correct is presented');
                             $container.find('.item-answer .tab[data-tab-name="correct"] .action').click();
                         } else {
@@ -514,7 +510,7 @@ define([
                         }
                     })
                     .then(() => {
-                        if (data.expected.showScore && data.expected.showCorrect) {
+                        if (data.expected.showCorrect) {
                             assert.strictEqual($item.find('.result-area [data-identifier="choice_1"]').length, 1, 'Choice #1 is selected');
                             assert.strictEqual($item.find('.choice-area [data-identifier="choice_2"]').length, 1, 'Choice #2 is not selected');
                             assert.strictEqual($item.find('.choice-area [data-identifier="choice_3"]').length, 1, 'Choice #3 is not selected');
@@ -536,8 +532,12 @@ define([
                             .next();
                     }))
                     .then(() => {
-                        assert.strictEqual($container.find('.item-answer').is('.incorrect'), data.expected.showScore, 'The component is set to "incorrect"');
-                        if (data.expected.showScore && data.expected.showCorrect) {
+                        if (data.expected.showScore) {
+                            assert.strictEqual($container.find('.item-answer').is('.incorrect'), true, 'The component is set to "incorrect"');
+                        } else {
+                            assert.strictEqual($container.find('.item-answer').is('.default'), true, 'The component is set to "default"');
+                        }
+                        if (data.expected.showCorrect) {
                             assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 2, 'Two tabs should be present');
                         } else {
                             assert.strictEqual($container.find('.item-answer-tabs .answer-tabs .tab').length, 1, 'Only one tab should be present');


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/INF-263

If claims were `showCorrect=true` & `showScore=false`, then "_Correct response_" tab was never shown. But it should be shown.

[Launch link example](https://devkit-oat-dev.dev.gcp-eu.taocloud.org/platform/message/launch/submission-review?registration=Kitchen%20Tool&user_list=c3po&ags_scopes%5B0%5D=https://purl.imsglobal.org/spec/lti-ags/scope/lineitem&ags_line_item_url=test&for_user_type=other&for_user_id=test_unanswered&for_user_name=test_unanswered&submission_review_url=https://lti1p3-platform.playground.kitchen.it.taocloud.org/ltiTestReview/ReviewTool/launch1p3?delivery%3Dhttps%253A%252F%252Flti1p3-platform.playground.kitchen.it.taocloud.org%252Ftao.rdf%2523i6572f1826f324185ecffd6a2e7b90783&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Instructor%22%0D%0A%20%20%20%20%5D,%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/custom%22:%20%7B%0D%0A%20%20%20%20%20%20%20%20%22custom_show_score%22:%20%22false%22,%0D%0A%20%20%20%20%20%20%20%20%22custom_show_correct%22:%20%22true%22%0D%0A%20%20%20%20%7D%0D%0A%7D)
Can be tested on remote env by using local overrides of js files from this PR.

Behavior for "Correct tab" should now match old behavior before https://oat-sa.atlassian.net/browse/INF-202 changes:
https://github.com/oat-sa/extension-lti-test-review/blob/v3.9.0/views/js/review/plugins/content/item-answer/item-answer.js#L165-L188
https://github.com/oat-sa/extension-lti-test-review/blob/v3.9.0/views/js/review/plugins/content/item-answer/plugin.js#L150-L165

Notes:
- looks like before "Correct tab" was always shown if `item.skipped`, but was that consequence of INF-202 problem? If it's possible for item to not have score/maxScore, but to have correct-response defined, then "Correct tab" should also be shown not only for empty answers, but for all answers?
- manually-scored items (ExtendedText essay) shouldn't have correct response defined, but since old solution was based on _"score"_ check, current is too. (I think there's not enough data? Manually scored item examples on oat-dev do have 
_"match correct"_ response processing defined)