### PR TITLE
Fix: pick becomes pickBy with lodash 4

### DIFF
--- a/views/js/review/services/navigation-data.js
+++ b/views/js/review/services/navigation-data.js
@@ -160,7 +160,7 @@ define([
                         part = Object.assign({}, part, {
                             sections: _.reduce(part.sections, (sections, section, sectionId) => {
                                 section = Object.assign({}, section, {
-                                    items: _.pick(section.items, filter)
+                                    items: _.pickBy(section.items, filter)
                                 });
 
                                 if (_.size(section.items)) {


### PR DESCRIPTION
A unit test was hanging, and failing:
<img width="959" alt="Screenshot 2024-05-24 at 12 02 24" src="https://github.com/oat-sa/extension-lti-test-review/assets/43652944/506b8228-ec9b-4437-9b9c-e45523b0d49f">

Problem is visible in CI action since 3 months: https://github.com/oat-sa/extension-lti-test-review/actions/workflows/continuous-integration.yaml

This coincides with the lodash upgrade from 2 -> 4, even though no change was made in this repo at the time, it should have been.

`_.pick(function)` must become `_.pickBy(function)`. [Docs](https://lodash.com/docs/4.17.15#pickBy).

Test now passes again, with `npx grunt connect:test ltitestreviewtest`