### PR TITLE
fix: fixed launch of lti1.0 reviews

### DIFF
--- a/controller/Review.php
+++ b/controller/Review.php
@@ -34,16 +34,13 @@ use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyAwareTrait;
 use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
 use oat\ltiDeliveryProvider\model\execution\LtiContextRepositoryInterface;
-use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\ltiTestReview\models\DeliveryExecutionFinderService;
 use oat\ltiTestReview\models\QtiRunnerInitDataBuilderFactory;
 use oat\tao\model\http\HttpJsonResponseTrait;
 use oat\tao\model\mvc\DefaultUrlService;
-use oat\taoLti\models\classes\LtiClientException;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiInvalidLaunchDataException;
 use oat\taoLti\models\classes\LtiLaunchData;
-use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 use oat\taoLti\models\classes\LtiService;
 use oat\taoLti\models\classes\LtiVariableMissingException;
 use oat\taoLti\models\classes\TaoLtiSession;
@@ -297,17 +294,9 @@ class Review extends tao_actions_SinglePageModule
         return $this->getPsrContainer()->get(QtiRunnerInitDataBuilderFactory::SERVICE_ID);
     }
 
-    /**
-     * @throws LtiClientException
-     */
-    private function getDeliveryId(): string
+    private function getDeliveryId(): ?string
     {
-        $deliveryId = $this->getPsrRequest()->getQueryParams()['delivery'] ?? null;
-        if ($deliveryId !== null) {
-            return $deliveryId;
-        }
-
-        throw new LtiClientException(__('Delivery id not provided'), LtiErrorMessage::ERROR_MISSING_PARAMETER);
+        return $this->getPsrRequest()->getQueryParams()['delivery'] ?? null;
     }
 
     /**

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -146,7 +146,7 @@ class DeliveryExecutionFinderService extends ConfigurableService
     /**
      * @param TaoLtiSession $ltiSession
      * @param bool $isSubmissionReviewRequestMessageProvided
-     * @param string $deliveryId
+     * @param ?string $deliveryId
      * @param string $userId
      * @return DeliveryExecution
      * @throws LtiClientException
@@ -154,11 +154,17 @@ class DeliveryExecutionFinderService extends ConfigurableService
     public function getExecution(
         TaoLtiSession $ltiSession,
         bool $isSubmissionReviewRequestMessageProvided,
-        string $deliveryId,
+        ?string $deliveryId,
         string $userId
     ): DeliveryExecution {
         $launchData = $ltiSession->getLaunchData();
         if ($isSubmissionReviewRequestMessageProvided) {
+            if ($deliveryId === null) {
+                throw new LtiClientException(
+                    __('Delivery id not provided'),
+                    LtiErrorMessage::ERROR_MISSING_PARAMETER
+                );
+            }
             $resourceLinkId = null;
             if ($launchData->hasVariable(LtiLaunchData::RESOURCE_LINK_ID)) {
                 $resourceLinkId = $ltiSession->getLtiLinkResource();


### PR DESCRIPTION
Fixing launching LTI1.0 request for test review using `basic-lti-launch-request` type

https://oat-sa.atlassian.net/browse/TR-6663?focusedCommentId=323460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved handling of missing delivery identifiers during review to avoid silent failures.
  - Clearer validation with explicit, user-facing errors when a delivery ID is required for submission review.
  - More reliable review loading across different launch contexts.

- Refactor
  - Streamlined parameter handling between review components for consistent behavior.
  - Removed unused dependencies to reduce overhead and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->