### PR TITLE
fix: fullname restriction

### DIFF
--- a/controller/Review.php
+++ b/controller/Review.php
@@ -314,7 +314,7 @@ class Review extends tao_actions_SinglePageModule
     private function getUserFullName(): string
     {
         if ($this->isSubmissionReviewRequestMessageProvided()) {
-            return $this->ltiSession->getLaunchData()->getUserFullName();
+            return $this->ltiSession->getLaunchData()->getUserFullName() ?? '';
         }
 
         return '';


### PR DESCRIPTION
**What changed**
Create fallback for cases when fullname is not defined.  

**Why**
When fullname was empty type exception has been thrown

**Testing**
https://github.com/user-attachments/assets/7750b032-6400-436d-996a-d05c4e9e374b

1. Create Test, Publish
2. Launch LTI Test as an test taker:
```
https://devkit.ngs.test/platform/message/launch/lti-resource-link?registration=devkit__backoffice&user_type=custom&user_list=c3po&custom_user_id=my-user-id-04&custom_user_name=My%20user%20Name%2003&launch_url=https://backoffice.ngs.test/ltiDeliveryProvider/DeliveryTool/launch1p3?delivery%3Dhttps%253A%252F%252Fbackoffice.ngs.test%252Fontologies%252Ftao.rdf%2523i6968a1fcb6a4d202601150914522a3d03c4&claims=%7B%0D%0A%20%20%20%20%22locale%22:%20%22ja-JP%22,%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D,%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti-ags/claim/endpoint%22:%20%7B%0D%0A%20%20%20%20%20%20%20%20%22scope%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%22https://purl.imsglobal.org/spec/lti-ags/scope/lineitem%22,%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%22https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly%22,%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%22https://purl.imsglobal.org/spec/lti-ags/scope/score%22%0D%0A%20%20%20%20%20%20%20%20%5D,%0D%0A%20%20%20%20%20%20%20%20%22lineitems%22:%20%22https://ltidevkit.ngdle.io/platform/service/ags/default/lineitems%22,%0D%0A%20%20%20%20%20%20%20%20%22lineitem%22:%20%22https://ltidevkit.ngdle.io/platform/service/ags/default/lineitems/cbt10Infosign%22%0D%0A%20%20%20%20%7D%0D%0A%7D
```

3. Lanuch LTI test review. Make sure Custom user name is left empty:
```
https://devkit.ngs.test/platform/message/launch/submission-review?registration=devkit__backoffice&user_type=custom&user_list=c3po&custom_user_id=my-user-id-04&ags_scopes%5B0%5D=https://purl.imsglobal.org/spec/lti-ags/scope/score&ags_line_item_url=http://ltidevkit.ngdle.io/platform/service/ags/default/lineitems/cbt10Infosign&submission_review_url=https://backoffice.ngs.test/ltiTestReview/ReviewTool/launch1p3?delivery%3Dhttps%253A%252F%252Fbackoffice.ngs.test%252Fontologies%252Ftao.rdf%2523i6968a1fcb6a4d202601150914522a3d03c4&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D,%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/custom%22:%20%7B%0D%0A%20%20%20%20%20%20%20%20%22custom_show_score%22:%20%22true%22,%0D%0A%20%20%20%20%20%20%20%20%22custom_show_correct%22:%20%22true%22,%0D%0A%20%20%20%20%20%20%20%20%22deliverySettings.review.testTakerFullName%22:%20%22true%22%0D%0A%20%20%20%20%7D%0D%0A%7D
```