### PR TITLE
Escape html in plain extended text

### DIFF
--- a/views/js/review/plugins/content/item-answer/plugin.js
+++ b/views/js/review/plugins/content/item-answer/plugin.js
@@ -44,14 +44,17 @@ define([
             response = responses[itemIdentifier];
             const toBeEscaped = [];
             const itemData = dataHolder.get('itemData');
-            Object.values(itemData.content.data.body.elements).forEach(el => {
-                if (['plain', 'preformatted'].includes(el.attributes.format) && el.attributes.responseIdentifier)
-                    toBeEscaped.push(el.attributes.responseIdentifier);
-            });
+            const elements = itemData?.content?.data?.body?.elements;
+            if (elements) {
+                Object.values(elements).forEach(el => {
+                    if (['plain', 'preformatted'].includes(el.attributes?.format) && el.attributes?.responseIdentifier)
+                        toBeEscaped.push(el.attributes.responseIdentifier);
+                });
+            }
             if (toBeEscaped.length) {
                 const clonedResponse = _.cloneDeep(response);
                 for (const key of Object.keys(response)) {
-                    if (toBeEscaped.includes(key)) {
+                    if (toBeEscaped.includes(key) && typeof clonedResponse[key]?.response?.base?.string === 'string') {
                         clonedResponse[key].response.base.string = _.escape(clonedResponse[key].response.base.string);
                     }
                 }

--- a/views/js/review/plugins/content/item-answer/plugin.js
+++ b/views/js/review/plugins/content/item-answer/plugin.js
@@ -42,6 +42,21 @@ define([
             const { itemIdentifier } = context;
             const responses = dataHolder.get('testResponses');
             response = responses[itemIdentifier];
+            const toBeEscaped = [];
+            const itemData = dataHolder.get('itemData');
+            Object.values(itemData.content.data.body.elements).forEach(el => {
+                if (['plain', 'preformatted'].includes(el.attributes.format) && el.attributes.responseIdentifier)
+                    toBeEscaped.push(el.attributes.responseIdentifier);
+            });
+            if (toBeEscaped.length) {
+                const clonedResponse = _.cloneDeep(response);
+                for (const key of Object.keys(response)) {
+                    if (toBeEscaped.includes(key)) {
+                        clonedResponse[key].response.base.string = _.escape(clonedResponse[key].response.base.string);
+                    }
+                }
+                response = clonedResponse;
+            }
         }
 
         return response;


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/INF-443

## What's Changed
Escapes html in extended text areas which are plain text or pre-formatted. These were incorrectly displaying as html.

## To Test
Create a test with extended text areas of these types, and paste in html. Review the test using the qtiTestReview component. They should not appear rendered.
These steps can be followed locally to do this:

First of all, add the following to your local_override.libsonnet:
```
{
  config+:: {
    tao+: {
      environment_variables+: {
        FEATURE_FLAG_TAO_ADVANCE_ONLY: 'false',
        FEATURE_FLAG_TAO_CG_ONLY: 'true',
      },
    },
  },
}
```
Spin up the whole thing via make dcupd.
In https://backoffice.ngs.test/, publish a local delivery (see screenshot 1)

Copy the published delivery ID (see screenshot 2)
<img width="1782" height="1054" alt="image" src="https://github.com/user-attachments/assets/d64ad200-3207-442a-99d9-96204070947a" />
<img width="1834" height="1052" alt="image" src="https://github.com/user-attachments/assets/de71a413-3788-4e28-a091-42cc266b350c" />

URL-encode the copied delivery ID, launch and complete a non-anonymous assessment via DevKit [like this](https://devkit.ngs.test/platform/message/launch/lti-resource-link?registration=devkit__backoffice&user_type=list&user_list=c3po&launch_url=https://backoffice.ngs.test/ltiDeliveryProvider/DeliveryTool/launch1p3?delivery%3Dhttps%253A%252F%252Fbackoffice.ngs.test%252Fontologies%252Ftao.rdf%2523i69943b41a98aa202602171056178884fbf2&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D%0D%0A%7D) (follow the link).
Now, launch its review, using the same user; use this [link](https://devkit.ngs.test/platform/message/launch/submission-review?registration=devkit__backoffice&user_type=list&user_list=c3po&ags_scopes%5B0%5D=https://purl.imsglobal.org/spec/lti-ags/scope/score&ags_line_item_url=https://google.com&submission_review_url=https://backoffice.ngs.test/ltiTestReview/ReviewTool/launch1p3?delivery%3Dhttps%253A%252F%252Fbackoffice.ngs.test%252Fontologies%252Ftao.rdf%2523i69943b41a98aa202602171056178884fbf2&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D%0D%0A%7D) to see an example.

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## TODO 
- [ ] Unit tests
- [ ] E2E tests
- [ ] Update with packages

## Dependencies PRs
- https://github.com/oat-sa/..

## How to test
- Explain here how to test or make a small demo to our team how this works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced escaping of response strings in the review plugin to properly handle plain text and preformatted content responses, ensuring improved data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->